### PR TITLE
Update for changes to ESS-DIVE Dataset API v2.4.0

### DIFF
--- a/.agents/skills/essdive-datasets/SKILL.md
+++ b/.agents/skills/essdive-datasets/SKILL.md
@@ -1,11 +1,17 @@
 ---
 name: essdive-datasets
-description: Search ESS-DIVE datasets, fetch metadata/permissions, and parse FLMD via MCP tools.
+description: Search ESS-DIVE datasets, fetch metadata/version history/permissions, and parse FLMD via MCP tools.
 ---
 
 # Setup (once)
 
 Run the MCP server locally:
+
+```bash
+uv run python src/essdive_mcp/main.py
+```
+
+If you need authenticated/private-data access, provide a token explicitly:
 
 ```bash
 uv run python src/essdive_mcp/main.py --token YOUR_ESS_DIVE_TOKEN_HERE
@@ -23,6 +29,12 @@ between ESS and DIVE).
 Register with Claude Code (stdio transport):
 
 ```bash
+claude mcp add --transport stdio essdive-mcp -- uv run python ./src/essdive_mcp/main.py
+```
+
+If you need authenticated/private-data access, add a token:
+
+```bash
 claude mcp add --transport stdio essdive-mcp --env ESSDIVE_API_TOKEN=YOUR_ESS_DIVE_TOKEN_HERE -- uv run python ./src/essdive_mcp/main.py
 ```
 
@@ -36,6 +48,7 @@ claude mcp add --transport stdio essdive-mcp -- uv run python ./src/essdive_mcp/
 
 - `search-datasets`
 - `get-dataset`
+- `get-dataset-versions`
 - `get-dataset-permissions`
 - `parse-flmd-file`
 - `lookup-project-portal`
@@ -120,6 +133,18 @@ Get detailed metadata for a dataset:
 get-dataset with id="ess-dive-9ea5fe57db73c90-20241024T093714082510"
 ```
 
+List version history from newest to oldest:
+
+```
+get-dataset-versions with id="doi:10.15485/2529445" and page_size=2
+```
+
+Follow a version-history cursor:
+
+```
+get-dataset-versions with id="doi:10.15485/2529445" and cursor="PASTE_NEXT_OR_PREVIOUS_CURSOR_HERE"
+```
+
 Check sharing permissions (requires token):
 
 ```
@@ -148,6 +173,8 @@ coords-to-map-links with bbox=[38.9187, -106.9532, 38.9263, -106.9451]
 
 - Use `format="summary"` for compact results, or `format="detailed"` for full metadata.
 - `page_size` max is 100; `row_start` is 1-based.
+- `get-dataset-versions` lists visible versions from newest to oldest and supports cursor pagination.
+- For `get-dataset-versions`, omit `page_size` on cursor follow-up calls unless you know it matches the cursor's encoded page size.
 - `bbox` uses `[min_lat, min_lon, max_lat, max_lon]` ordering and can also be passed as a comma-delimited string.
 - Point search requires `lat`, `lon`, and `radius` together. Do not combine point search with `bbox`.
 - Native ESS-DIVE `/packages` filters include `query`/`text`, `creator`, `provider_name`, `date_published`, `begin_date`, `end_date`, `keywords`, `bbox`, and `lat`/`lon`/`radius`.
@@ -190,4 +217,12 @@ curl -sG "https://api.ess-dive.lbl.gov/packages/REPLACE_WITH_PACKAGE_ID" \
   -H "User-Agent: Mozilla/5.0" \
   -H "Range: bytes=0-1000" \
   --data-urlencode "isPublic=true"
+```
+
+Fetch dataset version history by DOI or package ID:
+
+```bash
+curl -sG "https://api.ess-dive.lbl.gov/packages/doi%3A10.15485%2F2529445/versions" \
+  -H "Accept: application/json" \
+  --data-urlencode "pageSize=2"
 ```

--- a/.agents/skills/essdive-datasets/SKILL.md
+++ b/.agents/skills/essdive-datasets/SKILL.md
@@ -84,6 +84,18 @@ search-datasets with query="soil carbon" and sort="name:asc"
 search-datasets with query="soil carbon" and sort="dateUploaded:desc,authorLastName:asc"
 ```
 
+Follow a search cursor to the next page:
+
+```
+search-datasets with query="BIONTE" and sort="name:asc" and page_size=2
+```
+
+Then use the returned `nextCursor` or `previousCursor`:
+
+```
+search-datasets with query="BIONTE" and sort="name:asc" and cursor="PASTE_NEXT_OR_PREVIOUS_CURSOR_HERE"
+```
+
 Filter by bounding box:
 
 ```
@@ -182,7 +194,9 @@ coords-to-map-links with bbox=[38.9187, -106.9532, 38.9263, -106.9451]
 ## Notes
 
 - Use `format="summary"` for compact results, or `format="detailed"` for full metadata.
-- `page_size` max is 100; `row_start` is 1-based.
+- `page_size` max is 100.
+- `cursor` is the preferred way to page through search results. `row_start` is still supported for compatibility but is legacy.
+- For cursor follow-up searches, reuse the same search filters and omit `page_size` unless you know it matches the cursor's encoded page size.
 - `sort` accepts comma-separated `field:direction` clauses. Supported fields: `name`, `dateUploaded`, `authorLastName`. Supported directions: `asc`, `desc`.
 - `get-dataset-versions` lists visible versions from newest to oldest and supports cursor pagination.
 - For `get-dataset-versions`, omit `page_size` on cursor follow-up calls unless you know it matches the cursor's encoded page size.
@@ -206,6 +220,17 @@ curl -sG "https://api.ess-dive.lbl.gov/packages" \
   --data-urlencode "text=soil carbon" \
   --data-urlencode "pageSize=10" \
   --data-urlencode "rowStart=1" \
+  --data-urlencode "isPublic=true"
+```
+
+Follow a dataset-search cursor directly against the API:
+
+```bash
+curl -sG "https://api.ess-dive.lbl.gov/packages" \
+  -H "Accept: application/json" \
+  --data-urlencode "text=BIONTE" \
+  --data-urlencode "sort=name:asc" \
+  --data-urlencode "cursor=PASTE_NEXT_OR_PREVIOUS_CURSOR_HERE" \
   --data-urlencode "isPublic=true"
 ```
 

--- a/.agents/skills/essdive-datasets/SKILL.md
+++ b/.agents/skills/essdive-datasets/SKILL.md
@@ -74,6 +74,16 @@ Filter by temporal coverage:
 search-datasets with begin_date="2020" and end_date="2021-06" and format="detailed"
 ```
 
+Sort results by one or more API-supported fields:
+
+```
+search-datasets with query="soil carbon" and sort="name:asc"
+```
+
+```
+search-datasets with query="soil carbon" and sort="dateUploaded:desc,authorLastName:asc"
+```
+
 Filter by bounding box:
 
 ```
@@ -173,11 +183,12 @@ coords-to-map-links with bbox=[38.9187, -106.9532, 38.9263, -106.9451]
 
 - Use `format="summary"` for compact results, or `format="detailed"` for full metadata.
 - `page_size` max is 100; `row_start` is 1-based.
+- `sort` accepts comma-separated `field:direction` clauses. Supported fields: `name`, `dateUploaded`, `authorLastName`. Supported directions: `asc`, `desc`.
 - `get-dataset-versions` lists visible versions from newest to oldest and supports cursor pagination.
 - For `get-dataset-versions`, omit `page_size` on cursor follow-up calls unless you know it matches the cursor's encoded page size.
 - `bbox` uses `[min_lat, min_lon, max_lat, max_lon]` ordering and can also be passed as a comma-delimited string.
 - Point search requires `lat`, `lon`, and `radius` together. Do not combine point search with `bbox`.
-- Native ESS-DIVE `/packages` filters include `query`/`text`, `creator`, `provider_name`, `date_published`, `begin_date`, `end_date`, `keywords`, `bbox`, and `lat`/`lon`/`radius`.
+- Native ESS-DIVE `/packages` filters include `query`/`text`, `creator`, `provider_name`, `date_published`, `begin_date`, `end_date`, `keywords`, `sort`, `bbox`, and `lat`/`lon`/`radius`.
 - Additional filters such as `creator_affiliation`, `variable_measured`, `measurement_technique`, `funder`, `license`, `alternate_name`, `editor`, `file_format`, `file_name`, and `file_url` are applied locally after the initial API search using full dataset metadata from `get-dataset`.
 - If you need very precise filtering on those local-only fields, start with a narrower native search first, then apply the local metadata filters.
 - Local metadata filtering only inspects the current API page, so increase `page_size` or adjust `row_start` if you want to scan more native matches.

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ If you want a fuller manual setup, more client options, or more example queries,
 This project gives an AI client a set of tools for:
 
 - searching public ESS-DIVE datasets
-- fetching dataset metadata and sharing permissions
+- fetching dataset metadata, version history, and sharing permissions
 - converting between ESS-DIVE dataset IDs and DOIs
 - parsing File Level Metadata (FLMD) CSV content
 - searching ESS-DeepDive field and file metadata
@@ -520,6 +520,7 @@ Try prompts like:
 ### Dataset details and permissions
 
 - `Get the metadata for ESS-DIVE dataset ess-dive-165671432ae620e-20250908T210722395.`
+- `Show the version history for DOI 10.15485/2529445 and tell me what changed most recently.`
 - `Show the sharing permissions for ESS-DIVE dataset ess-dive-165671432ae620e-20250908T210722395.`
 
 ### Identifier conversion
@@ -722,6 +723,8 @@ search-datasets with query="East River" and creator_affiliation="Lawrence Berkel
 search-datasets with query="East River" and variable_measured="streamflow" and page_size=5
 search-datasets with query="East River" and funder="NASA" and page_size=5
 get-dataset with id="ess-dive-165671432ae620e-20250908T210722395"
+get-dataset-versions with id="doi:10.15485/2529445" and page_size=2
+get-dataset-versions with id="doi:10.15485/2529445" and cursor="PASTE_NEXT_CURSOR_HERE"
 get-dataset-permissions with id="ess-dive-165671432ae620e-20250908T210722395"
 doi-to-essdive-id with doi="10.15485/2587853"
 essdive-id-to-doi with essdive_id="ess-dive-165671432ae620e-20250908T210722395"
@@ -838,6 +841,7 @@ You can ask for a Skill by name, or let the agent choose it when relevant.
 Examples:
 
 - `Use the essdive-datasets skill to find recent wildfire-related datasets and then fetch the metadata for the best match.`
+- `Use the essdive-datasets skill to list the version history for DOI 10.15485/2529445 and summarize the newest two versions.`
 - `Use the essdive-identifiers skill to normalize DOI https://doi.org/10.15485/2587853 and return the ESS-DIVE ID.`
 - `Use the essdeepdive skill to search for temperature fields and tell me which data file each result comes from.`
 
@@ -893,6 +897,7 @@ and the observed values range from 19.1 to 26.9 C.
 
 - `search-datasets`
 - `get-dataset`
+- `get-dataset-versions`
 - `get-dataset-permissions`
 - `parse-flmd-file`
 

--- a/README.md
+++ b/README.md
@@ -512,6 +512,7 @@ Start with plain natural-language prompts. You do not need to call tool names di
 Try prompts like:
 
 - `Find public ESS-DIVE datasets about soil carbon and summarize the top five results.`
+- `Find public ESS-DIVE datasets about BIONTE sorted by name ascending.`
 - `Search ESS-DIVE for datasets inside the bounding box [38.9187, -106.9532, 38.9263, -106.9451].`
 - `Search ESS-DIVE for datasets within 100 meters of 38.8747, -76.5519 and summarize the results.`
 - `Find ESS-DIVE datasets published in 2024 about wildfire recovery.`
@@ -716,6 +717,7 @@ If your client supports direct tool calling, these examples map closely to the a
 
 ```text
 search-datasets with query="wildfire recovery" and page_size=5
+search-datasets with query="BIONTE" and sort="name:asc" and page_size=3
 search-datasets with begin_date="2020" and end_date="2021" and format="detailed"
 search-datasets with bbox=[38.9187, -106.9532, 38.9263, -106.9451]
 search-datasets with lat=38.8747 and lon=-76.5519 and radius=100
@@ -841,6 +843,7 @@ You can ask for a Skill by name, or let the agent choose it when relevant.
 Examples:
 
 - `Use the essdive-datasets skill to find recent wildfire-related datasets and then fetch the metadata for the best match.`
+- `Use the essdive-datasets skill to search for BIONTE datasets sorted by name ascending and summarize the first three.`
 - `Use the essdive-datasets skill to list the version history for DOI 10.15485/2529445 and summarize the newest two versions.`
 - `Use the essdive-identifiers skill to normalize DOI https://doi.org/10.15485/2587853 and return the ESS-DIVE ID.`
 - `Use the essdeepdive skill to search for temperature fields and tell me which data file each result comes from.`

--- a/README.md
+++ b/README.md
@@ -44,21 +44,21 @@ These are the minimum prerequisites:
   The best installation option will depend on your system. Once installation is complete, run Goose Desktop to complete the next step.
 - Access to an LLM API that Goose Desktop can use.
   Examples include OpenAI, Anthropic, or LBNL's CBORG. If you plan to use CBORG, see [docs/CBORG_SETUP.md](docs/CBORG_SETUP.md). Goose will prompt you to provide LLM API details when you first run it. For more details and visual examples, see [docs/GOOSE_SETUP.md](docs/GOOSE_SETUP.md).
-- An ESS-DIVE API token.
-  Sign in at <https://data.ess-dive.lbl.gov>. This generally requires authenticating with your ORCID. Once you have done so, open your profile (upper right), then go to the `Settings` tab -> `Authentication Token`. Create a new token or click the `Renew authentication token` button if you need a new token. Copy this token to a safe place.
+- An ESS-DIVE API token if you need authenticated access to private data.
+  Public dataset search and retrieval no longer require a token. If you do need one, sign in at <https://data.ess-dive.lbl.gov>. This generally requires authenticating with your ORCID. Once you have done so, open your profile (upper right), then go to the `Settings` tab -> `Authentication Token`. Create a new token or click the `Renew authentication token` button if you need a new token. Copy this token to a safe place.
 
 
 ⚠️ Important:
 
 - Goose Desktop must already be configured with your LLM provider and API key before the ESS-DIVE MCP extension will be usable.
-- The ESS-DIVE environment variable name must be exactly `ESSDIVE_API_TOKEN`.
-- ESS-DIVE says API tokens expire after 24 hours, so if the server suddenly stops authenticating, generate a fresh token and update the extension.
+- If you configure an ESS-DIVE token, the environment variable name must be exactly `ESSDIVE_API_TOKEN`.
+- ESS-DIVE says API tokens expire after 24 hours, so if authenticated requests suddenly stop working, generate a fresh token and update the extension.
 
 ### Install in Goose Desktop
 
 This is the simplest setup if you want Goose to run `essdive-mcp` directly from GitHub without cloning this repository first:
 
-1. Install Python, `uv`, Goose Desktop, and get your ESS-DIVE token as described above.
+1. Install Python, `uv`, and Goose Desktop as described above. If you need private-data access, also get an ESS-DIVE token.
 2. Open Goose Desktop and configure your LLM provider.
 3. Add a new Extension for `essdive-mcp`.
    Use one of these commands:
@@ -78,11 +78,13 @@ uvx --from git+https://github.com/ess-dive/essdive-mcp essdive-mcp
    - macOS/Linux command: `uvx`
    - macOS/Linux arguments: `--from git+https://github.com/ess-dive/essdive-mcp essdive-mcp`
 
-4. Set the extension environment variable:
+4. If you need private-data access, set the extension environment variable:
 
 ```text
 ESSDIVE_API_TOKEN=YOUR_ESS_DIVE_TOKEN_HERE
 ```
+
+   For public dataset search and retrieval, you can leave the ESS-DIVE token unset.
 
 After you save the extension, start a chat in Goose and ask a simple ESS-DIVE question. If the extension is working, Goose should call ESS-DIVE MCP tools automatically without you needing to type a tool name, though it will likely ask you for permission to use the tool first.
 
@@ -189,8 +191,8 @@ You do not need deep background knowledge to try this project.
 
 The simplest mental model is:
 
-1. Get an ESS-DIVE token.
-2. Start or register this MCP server.
+1. Start or register this MCP server.
+2. Optionally add an ESS-DIVE token if you need private-data access.
 3. Open your AI client.
 4. Ask questions in plain English.
 
@@ -303,7 +305,7 @@ If you prefer the manual command:
 uv sync
 ```
 
-### 4. Get an ESS-DIVE authentication token
+### 4. Optionally get an ESS-DIVE authentication token
 
 ESS-DIVE documents the token workflow in its Dataset API docs.
 
@@ -318,6 +320,8 @@ The easiest way to save it locally is:
 ```bash
 ./scripts/save_token.sh
 ```
+
+You only need this token if you want authenticated access, such as private datasets.
 
 Important:
 
@@ -338,16 +342,20 @@ The easiest way is:
 This script:
 
 - checks that `uv` is available
-- checks that your token file exists
-- starts the MCP server with that token file
+- starts the MCP server
+- uses `essdivetoken` automatically if that file exists
 
 If you prefer the manual command:
 
 ```bash
-uv run essdive-mcp --token-file ./essdivetoken
+uv run essdive-mcp
 ```
 
-(Note that this assumes you have saved your ESS-DIVE API token to a file named `essdivetoken`.)
+If you want authenticated/private-data access, you can still provide a token explicitly:
+
+```bash
+uv run essdive-mcp --token-file ./essdivetoken
+```
 
 What should happen:
 
@@ -363,7 +371,7 @@ Choose one of the following clients to use with the ESS-DIVE MCP server. Install
 If your preferred client is not listed here, look for that client's MCP server settings and configure it to run:
 
 ```bash
-uv run essdive-mcp --token-file ./essdivetoken
+uv run essdive-mcp
 ```
 
 Client Options:
@@ -386,12 +394,7 @@ Create a project-scoped MCP config at `.vscode/mcp.json`:
     "essdive-mcp": {
       "type": "stdio",
       "command": "uv",
-      "args": [
-        "run",
-        "essdive-mcp",
-        "--token-file",
-        "${workspaceFolder}/essdivetoken"
-      ]
+      "args": ["run", "essdive-mcp"]
     }
   }
 }
@@ -406,7 +409,7 @@ Then:
 5. Switch the chat mode to `Agent`.
 6. Open the tools list and confirm `essdive-mcp` is available.
 
-If you prefer not to keep the token in a file, you can use an environment variable instead:
+If you need authenticated/private-data access, you can add a token with an environment variable instead:
 
 ```json
 {
@@ -429,7 +432,7 @@ Register the server:
 
 ```bash
 claude mcp add --transport stdio essdive-mcp -- \
-  uv run essdive-mcp --token-file ./essdivetoken
+  uv run essdive-mcp
 ```
 
 Then check it:
@@ -444,6 +447,7 @@ Notes:
 
 - `--transport`, `--scope`, and `--env` flags must come before the server name.
 - Use `--scope project` if you want to share the server config with others in this repository.
+- Add `--env ESSDIVE_API_TOKEN=...` if you need authenticated/private-data access.
 
 ### Codex
 
@@ -451,7 +455,7 @@ Register the server:
 
 ```bash
 codex mcp add essdive-mcp -- \
-  uv run essdive-mcp --token-file ./essdivetoken
+  uv run essdive-mcp
 ```
 
 Or add it manually to `~/.codex/config.toml`:
@@ -459,8 +463,10 @@ Or add it manually to `~/.codex/config.toml`:
 ```toml
 [mcp_servers.essdive-mcp]
 command = "uv"
-args = ["run", "essdive-mcp", "--token-file", "/absolute/path/to/essdivetoken"]
+args = ["run", "essdive-mcp"]
 ```
+
+If you need authenticated/private-data access, add `ESSDIVE_API_TOKEN` to your Codex MCP server environment or pass `--token-file`.
 
 Then confirm it:
 
@@ -483,17 +489,17 @@ For a Goose Desktop extension that runs directly from GitHub without cloning thi
 - Windows arguments: `--from git+https://github.com/ess-dive/essdive-mcp essdive-mcp`
 - macOS/Linux command: `uvx`
 - macOS/Linux arguments: `--from git+https://github.com/ess-dive/essdive-mcp essdive-mcp`
-- Environment: `ESSDIVE_API_TOKEN=YOUR_ESS_DIVE_TOKEN_HERE`
+- Environment: optional `ESSDIVE_API_TOKEN=YOUR_ESS_DIVE_TOKEN_HERE`
 - Timeout: `300`
 
 If you already cloned this repository and want Goose to run your local checkout instead, add a custom STDIO extension with:
 
 - Name: `essdive-mcp`
 - Command: `uv`
-- Arguments: `run essdive-mcp --token-file /absolute/path/to/essdivetoken`
+- Arguments: `run essdive-mcp`
 - Timeout: `300`
 
-If you prefer environment variables, set:
+If you need authenticated/private-data access, set:
 
 - `ESSDIVE_API_TOKEN=YOUR_ESS_DIVE_TOKEN_HERE`
 
@@ -753,7 +759,7 @@ If you want the simplest way to try these Skills in Goose Desktop, use Goose's s
 What you need first:
 
 - Goose Desktop installed and configured with an LLM provider
-- an ESS-DIVE API token available for ESS-DIVE queries
+- an ESS-DIVE API token if you need authenticated/private-data ESS-DIVE queries
 
 You do not need Python or `uv` just to install the Skill files themselves.
 
@@ -911,13 +917,13 @@ and the observed values range from 19.1 to 26.9 C.
 
 ## Command-Line Options
 
-- `--token`, `-t`: provide an ESS-DIVE API token directly
-- `--token-file`: read the token from a file
+- `--token`, `-t`: provide an optional ESS-DIVE API token directly
+- `--token-file`: read an optional ESS-DIVE API token from a file
 - `--verbose`, `-v`: enable debug logging and include tracebacks in tool error responses
 
 ## Environment Variables
 
-- `ESSDIVE_API_TOKEN`: ESS-DIVE API token
+- `ESSDIVE_API_TOKEN`: optional ESS-DIVE API token for authenticated/private-data access
 - `ESSDIVE_MCP_VERBOSE`: set to `1`, `true`, `yes`, or `on` for verbose diagnostics
 
 ## Testing
@@ -928,7 +934,13 @@ Run unit tests:
 uv run pytest tests/ -m "not integration"
 ```
 
-Run live integration tests:
+Run live integration tests for public anonymous access:
+
+```bash
+uv run pytest tests/integration -m integration
+```
+
+To also run authenticated ESS-DIVE integration coverage, set:
 
 ```bash
 export ESSDIVE_API_TOKEN="YOUR_ESS_DIVE_TOKEN_HERE"
@@ -948,15 +960,19 @@ Check:
 1. the server is registered correctly
 2. the server is started
 3. your client is in agent mode if required
-4. your token is valid
+4. if you need private-data access, your token is valid
 
 ### I get an authentication error
 
-Refresh your ESS-DIVE token and try again. ESS-DIVE says tokens expire after 24 hours.
+Public dataset reads should not require a token. If authenticated/private-data requests fail, refresh your ESS-DIVE token and try again. ESS-DIVE says tokens expire after 24 hours.
 
-### I set an environment variable but the server still fails
+### I set an environment variable but authenticated requests still fail
 
 The variable name must be exactly `ESSDIVE_API_TOKEN`.
+
+### I don't see all the results I expect from a dataset search
+
+Search results will depend upon your access to private data. Datasets you do not have access to will not appear in search results. Check on the validity of your ESS-DIVE token if you are using one (see the previous two issues), verify that the entries you expect to see are either public or you have access to them, and re-try the search.
 
 ### I am at LBNL and want to use CBORG-backed models
 

--- a/README.md
+++ b/README.md
@@ -718,6 +718,7 @@ If your client supports direct tool calling, these examples map closely to the a
 ```text
 search-datasets with query="wildfire recovery" and page_size=5
 search-datasets with query="BIONTE" and sort="name:asc" and page_size=3
+search-datasets with query="BIONTE" and sort="name:asc" and cursor="PASTE_NEXT_CURSOR_HERE"
 search-datasets with begin_date="2020" and end_date="2021" and format="detailed"
 search-datasets with bbox=[38.9187, -106.9532, 38.9263, -106.9451]
 search-datasets with lat=38.8747 and lon=-76.5519 and radius=100
@@ -844,6 +845,7 @@ Examples:
 
 - `Use the essdive-datasets skill to find recent wildfire-related datasets and then fetch the metadata for the best match.`
 - `Use the essdive-datasets skill to search for BIONTE datasets sorted by name ascending and summarize the first three.`
+- `Use the essdive-datasets skill to search for BIONTE datasets, then continue to the next page with the returned cursor.`
 - `Use the essdive-datasets skill to list the version history for DOI 10.15485/2529445 and summarize the newest two versions.`
 - `Use the essdive-identifiers skill to normalize DOI https://doi.org/10.15485/2587853 and return the ESS-DIVE ID.`
 - `Use the essdeepdive skill to search for temperature fields and tell me which data file each result comes from.`

--- a/docs/GOOSE_SETUP.md
+++ b/docs/GOOSE_SETUP.md
@@ -18,13 +18,14 @@ You need all of the following:
 - Python `3.10` or newer
 - `uv`
 - Goose Desktop
-- an ESS-DIVE API token
+- an ESS-DIVE API token if you need authenticated/private-data access
 - access to an LLM API that Goose can use
 
 Important:
 
 - Goose must be configured with a working model provider before the ESS-DIVE MCP extension will be useful.
-- The ESS-DIVE token environment variable name must be exactly `ESSDIVE_API_TOKEN`.
+- Public ESS-DIVE dataset search and retrieval do not require a token.
+- If you configure an ESS-DIVE token, the environment variable name must be exactly `ESSDIVE_API_TOKEN`.
 - ESS-DIVE API tokens expire after 24 hours.
 
 If you plan to use Berkeley Lab CBORG as your LLM provider, see [CBORG_SETUP.md](./CBORG_SETUP.md).
@@ -127,7 +128,7 @@ In Goose Desktop:
 3. Click `Add custom extension`.
 4. Choose a command-line or `Standard IO` extension if Goose asks for a type.
 5. Enter the ESS-DIVE MCP command.
-6. Add the `ESSDIVE_API_TOKEN` environment variable.
+6. If you need authenticated/private-data access, add the `ESSDIVE_API_TOKEN` environment variable.
 7. Save the extension.
 
 ### Recommended extension values
@@ -169,7 +170,7 @@ If Goose asks for command and arguments separately, use:
 - macOS/Linux command: `uvx`
 - macOS/Linux arguments: `--from git+https://github.com/ess-dive/essdive-mcp essdive-mcp`
 
-### Environment Variable To Add
+### Optional Environment Variable
 
 Add this environment variable to the extension:
 
@@ -177,15 +178,17 @@ Add this environment variable to the extension:
 ESSDIVE_API_TOKEN=YOUR_ESS_DIVE_TOKEN_HERE
 ```
 
-This lets Goose pass your ESS-DIVE token to the MCP server without needing a separate local token file.
+This lets Goose pass your ESS-DIVE token to the MCP server without needing a separate local token file. For public dataset reads, you can leave this unset.
 
 ### Local Checkout Alternative
 
 If you already cloned this repository and want Goose to run your local copy of the ESS-DIVE MCP instead of downloading from GitHub each time, you can use:
 
 ```text
-uv run essdive-mcp --token-file /absolute/path/to/essdivetoken
+uv run essdive-mcp
 ```
+
+If you need authenticated/private-data access in a local checkout, add `--token-file /absolute/path/to/essdivetoken` or set `ESSDIVE_API_TOKEN`.
 
 That option is better for development or testing local changes. For most users, `uvx` is simpler.
 
@@ -232,7 +235,7 @@ Check all of the following:
 
 ### Authentication errors from ESS-DIVE
 
-Goose may return a message like "It seems that I'm currently unable to access public datasets from the ESS-DIVE API due to authorization issues.".
+Public dataset reads should work without a token. If authenticated/private-data requests fail, Goose may return an authorization error.
 
 Usually this means:
 

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -124,6 +124,7 @@ To remove them:
 ### `essdive-datasets`
 
 - `Use the essdive-datasets skill to find public ESS-DIVE datasets about wildfire recovery and summarize the top results.`
+- `Use the essdive-datasets skill to search for BIONTE datasets sorted by name ascending and summarize the first three.`
 - `Use the essdive-datasets skill to search for datasets inside the bounding box [38.9187, -106.9532, 38.9263, -106.9451] and summarize the matches.`
 - `Use the essdive-datasets skill to search for datasets within 100 meters of 38.8747, -76.5519 and summarize the matches.`
 - `Use the essdive-datasets skill to show the version history for DOI 10.15485/2529445 and summarize the newest two versions.`

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -125,6 +125,7 @@ To remove them:
 
 - `Use the essdive-datasets skill to find public ESS-DIVE datasets about wildfire recovery and summarize the top results.`
 - `Use the essdive-datasets skill to search for BIONTE datasets sorted by name ascending and summarize the first three.`
+- `Use the essdive-datasets skill to search for BIONTE datasets, then continue to the next page with the returned cursor.`
 - `Use the essdive-datasets skill to search for datasets inside the bounding box [38.9187, -106.9532, 38.9263, -106.9451] and summarize the matches.`
 - `Use the essdive-datasets skill to search for datasets within 100 meters of 38.8747, -76.5519 and summarize the matches.`
 - `Use the essdive-datasets skill to show the version history for DOI 10.15485/2529445 and summarize the newest two versions.`

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -58,7 +58,7 @@ The shared project reference file lives at [`../.agents/skills/references/essdiv
 
 ### `essdive-datasets`
 
-Search ESS-DIVE datasets with keyword, temporal, and geographic filters; fetch metadata and permissions; and parse FLMD CSV content.
+Search ESS-DIVE datasets with keyword, temporal, and geographic filters; fetch metadata, version history, and permissions; and parse FLMD CSV content.
 
 See [`../.agents/skills/essdive-datasets/SKILL.md`](../.agents/skills/essdive-datasets/SKILL.md).
 
@@ -126,6 +126,7 @@ To remove them:
 - `Use the essdive-datasets skill to find public ESS-DIVE datasets about wildfire recovery and summarize the top results.`
 - `Use the essdive-datasets skill to search for datasets inside the bounding box [38.9187, -106.9532, 38.9263, -106.9451] and summarize the matches.`
 - `Use the essdive-datasets skill to search for datasets within 100 meters of 38.8747, -76.5519 and summarize the matches.`
+- `Use the essdive-datasets skill to show the version history for DOI 10.15485/2529445 and summarize the newest two versions.`
 - `Use the essdive-datasets skill to search for East River datasets and then keep only results with Lawrence Berkeley Lab creator affiliations.`
 - `Use the essdive-datasets skill to search for East River datasets and then keep only results where variableMeasured includes streamflow.`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "essdive-mcp"
-version = "0.2.6"
+version = "0.2.7"
 description = "MCP Server for ESS-DIVE API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/start_server.sh
+++ b/scripts/start_server.sh
@@ -12,14 +12,16 @@ if ! command -v uv >/dev/null 2>&1; then
   exit 1
 fi
 
-if [[ ! -f "$TOKEN_FILE" ]] || [[ ! -s "$TOKEN_FILE" ]]; then
-  echo "Token file not found at $TOKEN_FILE" >&2
-  echo "Create one with ./scripts/save_token.sh or set ESSDIVE_TOKEN_FILE." >&2
-  exit 1
+if [[ -f "$TOKEN_FILE" ]] && [[ -s "$TOKEN_FILE" ]]; then
+  echo "Starting essdive-mcp using token file: $TOKEN_FILE"
+  echo "The server will wait for an MCP client connection. Press Ctrl+C to stop."
+  echo
+  exec uv run essdive-mcp --token-file "$TOKEN_FILE"
 fi
 
-echo "Starting essdive-mcp using token file: $TOKEN_FILE"
+echo "No token file found at $TOKEN_FILE; starting essdive-mcp without ESS-DIVE auth."
+echo "Public dataset reads will work anonymously. Set ESSDIVE_API_TOKEN or create a token file if you need private-data access."
 echo "The server will wait for an MCP client connection. Press Ctrl+C to stop."
 echo
 
-exec uv run essdive-mcp --token-file "$TOKEN_FILE"
+exec uv run essdive-mcp

--- a/src/essdive_mcp/main.py
+++ b/src/essdive_mcp/main.py
@@ -1711,6 +1711,21 @@ def get_api_key(
     return api_key or None
 
 
+def _resolve_startup_api_token(
+    api_key: Optional[str] = None,
+    token_file: Optional[str] = None,
+) -> Optional[str]:
+    """Resolve startup auth config, falling back to anonymous mode on file errors."""
+    try:
+        return get_api_key(api_key, token_file=token_file)
+    except ValueError as exc:
+        LOGGER.warning(
+            "%s Starting without ESS-DIVE auth; public dataset reads will still work.",
+            exc,
+        )
+        return None
+
+
 def main():
     """Main entry point for the MCP server."""
     # Parse command-line arguments
@@ -1735,7 +1750,7 @@ def main():
     verbose_mode = args.verbose or _is_truthy(os.getenv("ESSDIVE_MCP_VERBOSE"))
     _configure_logging(verbose_mode)
 
-    api_token = get_api_key(args.token, token_file=args.token_file)
+    api_token = _resolve_startup_api_token(args.token, token_file=args.token_file)
 
     LOGGER.info(
         "Starting ESS-DIVE MCP server (verbose=%s, authenticated=%s)",

--- a/src/essdive_mcp/main.py
+++ b/src/essdive_mcp/main.py
@@ -1128,7 +1128,8 @@ class ESSDiveClient:
             params["cursor"] = cursor
 
         url = self._package_url(identifier, "/versions")
-        LOGGER.debug("ESS-DIVE get dataset versions request url=%s params=%s", url, params)
+        LOGGER.debug(
+            "ESS-DIVE get dataset versions request url=%s params=%s", url, params)
 
         async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT_SECONDS) as client:
             response = await client.get(
@@ -1142,7 +1143,8 @@ class ESSDiveClient:
         LOGGER.debug(
             "ESS-DIVE get dataset versions response total=%s count=%s",
             result.get("total"),
-            len(result.get("result", [])) if isinstance(result, dict) else "n/a",
+            len(result.get("result", [])) if isinstance(
+                result, dict) else "n/a",
         )
         return result
 
@@ -1210,7 +1212,8 @@ class ESSDiveClient:
         datasets = results["result"]
         total = results.get("total", 0)
         filtering = results.get("filtering")
-        query = results.get("query", {}) if isinstance(results.get("query"), dict) else {}
+        query = results.get("query", {}) if isinstance(
+            results.get("query"), dict) else {}
         sort_value = query.get("sort")
 
         if filtering:

--- a/src/essdive_mcp/main.py
+++ b/src/essdive_mcp/main.py
@@ -41,7 +41,9 @@ MCP Tools Available:
   - coords-to-map-links: Convert points or a bounding box to viewable map links (e.g., geojson.io).
 
 Authentication:
-  API token can be provided via --token, --token-file, or ESSDIVE_API_TOKEN.
+  Public dataset reads do not require authentication. An API token can still be
+  provided via --token, --token-file, or ESSDIVE_API_TOKEN for authenticated
+  requests such as private-data access.
 """
 import asyncio
 import os
@@ -1223,7 +1225,8 @@ class ESSDiveClient:
                 if variables:
                     detailed += f"   Variables Measured: {', '.join(variables[:6])}\n"
 
-                techniques = _as_string_list(ds_data.get("measurementTechnique"))
+                techniques = _as_string_list(
+                    ds_data.get("measurementTechnique"))
                 if techniques:
                     detailed += (
                         f"   Measurement Techniques: "
@@ -1518,19 +1521,16 @@ def _summarize_essdeepdive_file_response(result: Dict[str, Any]) -> Dict[str, An
 
 def get_api_key(
     api_key: Optional[str] = None, token_file: Optional[str] = None
-) -> str:
+) -> Optional[str]:
     """
-    Get ESS-DIVE API key from parameter, token file, or environment variable.
+    Get an optional ESS-DIVE API token from a parameter, token file, or environment.
 
     Args:
         api_key: Optional API key provided directly.
         token_file: Optional path to a file containing the API key.
 
     Returns:
-        The API key string.
-
-    Raises:
-        ValueError: If no API key is provided or found in environment.
+        The API key string, or None when no token is configured.
     """
     if api_key is None and token_file:
         try:
@@ -1544,12 +1544,7 @@ def get_api_key(
     if not api_key:
         api_key = os.getenv("ESSDIVE_API_TOKEN")
 
-    if not api_key:
-        raise ValueError(
-            "ESS-DIVE API key is required. Provide it with --token, --token-file, or set ESSDIVE_API_TOKEN."
-        )
-
-    return api_key
+    return api_key or None
 
 
 def main():
@@ -1559,11 +1554,11 @@ def main():
     parser.add_argument(
         "--token",
         "-t",
-        help="ESS-DIVE API token for authenticated requests (can also use ESSDIVE_API_TOKEN env var)",
+        help="Optional ESS-DIVE API token for authenticated/private-data requests (can also use ESSDIVE_API_TOKEN env var)",
     )
     parser.add_argument(
         "--token-file",
-        help="Path to a file containing the ESS-DIVE API token",
+        help="Path to a file containing an optional ESS-DIVE API token",
     )
     parser.add_argument(
         "--verbose",
@@ -1576,13 +1571,13 @@ def main():
     verbose_mode = args.verbose or _is_truthy(os.getenv("ESSDIVE_MCP_VERBOSE"))
     _configure_logging(verbose_mode)
 
-    # Get and validate API token
-    try:
-        api_token = get_api_key(args.token, token_file=args.token_file)
-    except ValueError as exc:
-        parser.error(str(exc))
+    api_token = get_api_key(args.token, token_file=args.token_file)
 
-    LOGGER.info("Starting ESS-DIVE MCP server (verbose=%s)", verbose_mode)
+    LOGGER.info(
+        "Starting ESS-DIVE MCP server (verbose=%s, authenticated=%s)",
+        verbose_mode,
+        bool(api_token),
+    )
 
     # Create a FastMCP server
     server = FastMCP("essdive_mcp")
@@ -1863,7 +1858,8 @@ def main():
                     content += f"- {location}\n"
                 content += "\n"
 
-            variables_measured = _as_string_list(dataset.get("variableMeasured"))
+            variables_measured = _as_string_list(
+                dataset.get("variableMeasured"))
             if variables_measured:
                 content += "## Variables Measured\n"
                 content += ", ".join(variables_measured)
@@ -1881,7 +1877,8 @@ def main():
             funders = []
             for funder in _as_list(dataset.get("funder")):
                 if isinstance(funder, dict):
-                    funder_name = ", ".join(_organization_search_strings(funder))
+                    funder_name = ", ".join(
+                        _organization_search_strings(funder))
                     if funder_name:
                         funders.append(funder_name)
                 else:
@@ -2016,7 +2013,8 @@ def main():
         Returns:
             JSON string containing matching project reference entries
         """
-        LOGGER.debug("Tool lookup-project-portal called query=%r limit=%s", query, limit)
+        LOGGER.debug(
+            "Tool lookup-project-portal called query=%r limit=%s", query, limit)
         try:
             result = search_project_portals(query=query, limit=limit)
             return json.dumps(result, indent=2)
@@ -2025,7 +2023,8 @@ def main():
                 "lookup-project-portal",
                 exc,
                 verbose=verbose_mode,
-                context=_context_without_none({"query": query, "limit": limit}),
+                context=_context_without_none(
+                    {"query": query, "limit": limit}),
             )
 
     @server.tool(

--- a/src/essdive_mcp/main.py
+++ b/src/essdive_mcp/main.py
@@ -216,6 +216,11 @@ def _context_without_none(context: Dict[str, Any]) -> Dict[str, Any]:
     return {key: value for key, value in context.items() if value is not None}
 
 
+def _default_dataset_search_is_public(api_token: Optional[str]) -> Optional[bool]:
+    """Use public-only search anonymously; allow private matches when authenticated."""
+    return True if not api_token else None
+
+
 def _is_essdive_empty_search_response(response: httpx.Response) -> bool:
     """Return True when ESS-DIVE encodes an empty search result as HTTP 404."""
     if response.status_code != 404:
@@ -1874,7 +1879,7 @@ def main():
             result = await client.search_datasets(
                 row_start=row_start,
                 page_size=page_size,
-                is_public=True,
+                is_public=_default_dataset_search_is_public(client.api_token),
                 creator=creator,
                 provider_name=provider_name,
                 text=text,

--- a/src/essdive_mcp/main.py
+++ b/src/essdive_mcp/main.py
@@ -245,6 +245,7 @@ def _empty_dataset_search_result(
     begin_date: Optional[str],
     end_date: Optional[str],
     keywords: Optional[List[str]],
+    sort: Optional[str],
     bbox: Optional[str],
     lat: Optional[float],
     lon: Optional[float],
@@ -265,6 +266,7 @@ def _empty_dataset_search_result(
             "beginDate": begin_date,
             "endDate": end_date,
             "keywords": keywords,
+            "sort": sort,
             "bbox": bbox,
             "lat": lat,
             "lon": lon,
@@ -957,6 +959,7 @@ class ESSDiveClient:
         begin_date: Optional[str] = None,
         end_date: Optional[str] = None,
         keywords: Optional[List[str]] = None,
+        sort: Optional[str] = None,
         bbox: Optional[Union[str, List[float]]] = None,
         lat: Optional[float] = None,
         lon: Optional[float] = None,
@@ -976,6 +979,7 @@ class ESSDiveClient:
             begin_date: Filter by temporal coverage window start date
             end_date: Filter by temporal coverage window end date
             keywords: Search for datasets with specific keywords
+            sort: Sort order such as "name:asc" or "dateUploaded:desc,authorLastName:asc"
             bbox: Bounding box filter as "min_lat,min_lon,max_lat,max_lon" or [min_lat, min_lon, max_lat, max_lon]
             lat: Latitude for point-based nearby search
             lon: Longitude for point-based nearby search
@@ -988,6 +992,7 @@ class ESSDiveClient:
             await client.search_datasets(text="soil carbon", page_size=5, is_public=True)
             await client.search_datasets(provider_name="NGEE Arctic", row_start=1, page_size=10)
             await client.search_datasets(begin_date="2020", end_date="2021-06")
+            await client.search_datasets(text="soil carbon", sort="name:asc")
             await client.search_datasets(bbox=[34.0, -119.0, 35.0, -117.0])
         """
         params: Dict[str, Any] = {}
@@ -1019,6 +1024,8 @@ class ESSDiveClient:
             params["endDate"] = end_date
         if keywords:
             params["keywords"] = keywords
+        if sort:
+            params["sort"] = sort
         if normalized_bbox:
             params["bbox"] = normalized_bbox
         if lat is not None:
@@ -1052,6 +1059,7 @@ class ESSDiveClient:
                         begin_date=begin_date,
                         end_date=end_date,
                         keywords=keywords,
+                        sort=sort,
                         bbox=normalized_bbox,
                         lat=lat,
                         lon=lon,
@@ -1202,6 +1210,8 @@ class ESSDiveClient:
         datasets = results["result"]
         total = results.get("total", 0)
         filtering = results.get("filtering")
+        query = results.get("query", {}) if isinstance(results.get("query"), dict) else {}
+        sort_value = query.get("sort")
 
         if filtering:
             native_total = filtering.get("native_total")
@@ -1215,6 +1225,9 @@ class ESSDiveClient:
             header += ":\n\n"
         else:
             header = f"Found {total} datasets. Showing {len(datasets)} results:\n\n"
+
+        if sort_value:
+            header += f"Sort: {sort_value}\n\n"
 
         if format_type == "summary":
             summary = header
@@ -1738,6 +1751,7 @@ def main():
         begin_date: Optional[str] = None,
         end_date: Optional[str] = None,
         keywords: Optional[Union[str, List[str]]] = None,
+        sort: Optional[str] = None,
         bbox: Optional[Union[str, List[float]]] = None,
         lat: Optional[float] = None,
         lon: Optional[float] = None,
@@ -1767,6 +1781,7 @@ def main():
             begin_date: Temporal coverage window start date (YYYY, YYYY-MM, or YYYY-MM-DD)
             end_date: Temporal coverage window end date (YYYY, YYYY-MM, or YYYY-MM-DD)
             keywords: Search for datasets with specific keywords (string or list of strings)
+            sort: Optional sort string, e.g. "name:asc" or "dateUploaded:desc,authorLastName:asc"
             bbox: Bounding box search as "min_lat,min_lon,max_lat,max_lon" or [min_lat, min_lon, max_lat, max_lon]
             lat: Latitude for point-based nearby search
             lon: Longitude for point-based nearby search
@@ -1789,6 +1804,7 @@ def main():
             search-datasets with query="soil carbon" and page_size=10
             search-datasets with creator="Smith" and provider_name="NGEE Arctic"
             search-datasets with begin_date="2020" and end_date="2021-06" and format="detailed"
+            search-datasets with query="soil carbon" and sort="name:asc"
             search-datasets with bbox=[34.0, -119.0, 35.0, -117.0]
             search-datasets with lat=37.7749 and lon=-122.4194 and radius=5000
             search-datasets with query="snowmelt" and creator_affiliation="Pennsylvania"
@@ -1798,12 +1814,13 @@ def main():
             Formatted search results
         """
         LOGGER.debug(
-            "Tool search-datasets called query=%r creator=%r provider_name=%r begin_date=%r end_date=%r bbox=%r lat=%r lon=%r radius=%r local_filters=%r row_start=%s page_size=%s format=%s",
+            "Tool search-datasets called query=%r creator=%r provider_name=%r begin_date=%r end_date=%r sort=%r bbox=%r lat=%r lon=%r radius=%r local_filters=%r row_start=%s page_size=%s format=%s",
             query,
             creator,
             provider_name,
             begin_date,
             end_date,
+            sort,
             bbox,
             lat,
             lon,
@@ -1862,6 +1879,7 @@ def main():
                 begin_date=begin_date,
                 end_date=end_date,
                 keywords=keywords_list,
+                sort=sort,
                 bbox=bbox,
                 lat=lat,
                 lon=lon,
@@ -1895,6 +1913,7 @@ def main():
                         "date_published": date_published,
                         "begin_date": begin_date,
                         "end_date": end_date,
+                        "sort": sort,
                         "bbox": bbox,
                         "lat": lat,
                         "lon": lon,

--- a/src/essdive_mcp/main.py
+++ b/src/essdive_mcp/main.py
@@ -14,6 +14,8 @@ MCP Tools Available:
     records. Supports pagination and multiple result formats.
   - get-dataset: Retrieve detailed metadata for a specific dataset including creators,
     keywords, description, and available data files.
+  - get-dataset-versions: List visible versions of a dataset from newest to oldest,
+    with cursor-based pagination support for version history navigation.
   - get-dataset-permissions: Get sharing and access permission information for datasets.
 
 **Identifier Conversion:**
@@ -1087,6 +1089,55 @@ class ESSDiveClient:
                      result.get("id"))
         return result
 
+    async def get_dataset_versions(
+        self,
+        identifier: str,
+        page_size: Optional[int] = None,
+        cursor: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        List visible versions of a dataset from newest to oldest.
+
+        Args:
+            identifier: The ESS-DIVE unique identifier or DOI
+            page_size: Optional number of versions to return (API default: 10, max: 10)
+            cursor: Optional opaque cursor from a previous versions response
+
+        Returns:
+            API response containing dataset versions and pagination cursors
+
+        Examples:
+            await client.get_dataset_versions("doi:10.15485/2453885", page_size=5)
+            await client.get_dataset_versions(
+                "ess-dive-9ea5fe57db73c90-20241024T093714082510",
+                cursor="opaque-cursor",
+            )
+        """
+        params: Dict[str, Any] = {}
+        if page_size is not None:
+            params["pageSize"] = page_size
+        if cursor:
+            params["cursor"] = cursor
+
+        url = self._package_url(identifier, "/versions")
+        LOGGER.debug("ESS-DIVE get dataset versions request url=%s params=%s", url, params)
+
+        async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT_SECONDS) as client:
+            response = await client.get(
+                url,
+                params=params or None,
+                headers=self._get_headers(),
+            )
+            response.raise_for_status()
+            result = response.json()
+
+        LOGGER.debug(
+            "ESS-DIVE get dataset versions response total=%s count=%s",
+            result.get("total"),
+            len(result.get("result", [])) if isinstance(result, dict) else "n/a",
+        )
+        return result
+
     async def get_dataset_status(self, identifier: str) -> Dict[str, Any]:
         """
         Get the status of a dataset (DOI minting, publication, visibility).
@@ -1247,6 +1298,98 @@ class ESSDiveClient:
                     detailed += f"   License: {license_value}\n"
 
                 if i < len(datasets):
+                    detailed += "\n"
+
+            return detailed
+
+        return results
+
+    def format_dataset_versions(
+        self, results: Dict[str, Any], format_type: str = "summary"
+    ) -> Union[str, Dict[str, Any]]:
+        """
+        Format dataset version history into a readable summary.
+
+        Args:
+            results: The API response to format
+            format_type: Type of formatting ('summary', 'detailed', 'raw')
+
+        Returns:
+            Formatted version history as string or dict
+        """
+        if format_type == "raw":
+            return results
+
+        if "result" not in results:
+            return "No version history found or invalid response format."
+
+        versions = results["result"]
+        total = results.get("total", 0)
+        header = (
+            f"Found {total} visible dataset versions. "
+            f"Showing {len(versions)} results from newest to oldest:\n"
+        )
+
+        pagination = (
+            "\nPagination:\n"
+            f"  previousCursor: {results.get('previousCursor') or 'None'}\n"
+            f"  nextCursor: {results.get('nextCursor') or 'None'}\n\n"
+        )
+
+        if format_type == "summary":
+            summary = header + pagination
+
+            for i, version in enumerate(versions, 1):
+                dataset = version.get("dataset", {})
+                doi = dataset.get("@id") or dataset.get("doi")
+                summary += f"{i}. {dataset.get('name', 'Untitled')}\n"
+                summary += f"   ID: {version.get('id', 'Unknown')}\n"
+                if doi:
+                    summary += f"   DOI: {doi}\n"
+                summary += f"   Uploaded: {version.get('dateUploaded', 'Unknown')}\n"
+                summary += f"   Published: {dataset.get('datePublished', 'Unknown')}\n"
+                summary += f"   URL: {version.get('viewUrl', 'Unknown')}\n"
+                if i < len(versions):
+                    summary += "\n"
+
+            return summary
+
+        if format_type == "detailed":
+            detailed = header + pagination
+
+            for i, version in enumerate(versions, 1):
+                dataset = version.get("dataset", {})
+                doi = dataset.get("@id") or dataset.get("doi")
+                detailed += f"{i}. {dataset.get('name', 'Untitled')}\n"
+                detailed += f"   ID: {version.get('id', 'Unknown')}\n"
+                if doi:
+                    detailed += f"   DOI: {doi}\n"
+                detailed += f"   Uploaded: {version.get('dateUploaded', 'Unknown')}\n"
+                detailed += f"   Modified: {version.get('dateModified', 'Unknown')}\n"
+                detailed += f"   Published: {dataset.get('datePublished', 'Unknown')}\n"
+                detailed += f"   Public: {version.get('isPublic', 'Unknown')}\n"
+                detailed += f"   View URL: {version.get('viewUrl', 'Unknown')}\n"
+                detailed += f"   API URL: {version.get('url', 'Unknown')}\n"
+
+                description = dataset.get("description", "")
+                if isinstance(description, list):
+                    description = " ".join(description)
+                if description:
+                    detailed += (
+                        f"   Description: {description[:300]}"
+                        f"{'...' if len(description) > 300 else ''}\n"
+                    )
+
+                citation = version.get("citation")
+                if citation:
+                    detailed += f"   Citation: {citation}\n"
+
+                if version.get("next"):
+                    detailed += f"   Newer Version URL: {version['next']}\n"
+                if version.get("previous"):
+                    detailed += f"   Older Version URL: {version['previous']}\n"
+
+                if i < len(versions):
                     detailed += "\n"
 
             return detailed
@@ -1921,6 +2064,69 @@ def main():
                 exc,
                 verbose=verbose_mode,
                 context={"id": id},
+            )
+
+    @server.tool(
+        name="get-dataset-versions",
+        description="List visible versions of a specific dataset from newest to oldest",
+    )
+    async def get_dataset_versions_tool(
+        id: str,
+        page_size: Optional[int] = None,
+        cursor: Optional[str] = None,
+        format: str = "summary",
+    ) -> str:
+        """
+        List visible versions for a dataset from newest to oldest.
+
+        Args:
+            id: ESS-DIVE dataset identifier or DOI
+            page_size: Optional number of versions to return (API default: 10, max: 10)
+            cursor: Optional opaque cursor from a previous versions response
+            format: Format of the results (summary, detailed, raw)
+
+        Examples:
+            get-dataset-versions with id="doi:10.15485/2529445"
+            get-dataset-versions with id="doi:10.15485/2529445" and page_size=2
+            get-dataset-versions with id="doi:10.15485/2529445" and cursor="opaque-cursor"
+
+        Returns:
+            Formatted dataset version history
+        """
+        LOGGER.debug(
+            "Tool get-dataset-versions called id=%s page_size=%s cursor=%r format=%s",
+            id,
+            page_size,
+            cursor,
+            format,
+        )
+        try:
+            result = await client.get_dataset_versions(
+                id,
+                page_size=page_size,
+                cursor=cursor,
+            )
+            formatted = client.format_dataset_versions(result, format)
+
+            if format == "raw":
+                return json.dumps(formatted, indent=2)
+            if isinstance(formatted, dict):
+                return json.dumps(formatted, indent=2)
+            return str(formatted)
+
+        except Exception as exc:
+            return _tool_error_response(
+                "get-dataset-versions",
+                exc,
+                verbose=verbose_mode,
+                context=_context_without_none(
+                    {
+                        "id": id,
+                        "page_size": page_size,
+                        "cursor": cursor,
+                        "format": format,
+                    }
+                ),
             )
 
     @server.tool(

--- a/src/essdive_mcp/main.py
+++ b/src/essdive_mcp/main.py
@@ -240,8 +240,9 @@ def _is_essdive_empty_search_response(response: httpx.Response) -> bool:
 
 def _empty_dataset_search_result(
     *,
-    row_start: int,
-    page_size: int,
+    row_start: Optional[int],
+    page_size: Optional[int],
+    cursor: Optional[str],
     is_public: Optional[bool],
     creator: Optional[str],
     provider_name: Optional[str],
@@ -257,10 +258,8 @@ def _empty_dataset_search_result(
     radius: Optional[float],
 ) -> Dict[str, Any]:
     """Return a stable empty search payload when the API reports no matches."""
-    return {
+    payload = {
         "total": 0,
-        "pageSize": page_size,
-        "rowStart": row_start,
         "result": [],
         "query": {
             "isPublic": is_public,
@@ -272,12 +271,18 @@ def _empty_dataset_search_result(
             "endDate": end_date,
             "keywords": keywords,
             "sort": sort,
+            "cursor": cursor,
             "bbox": bbox,
             "lat": lat,
             "lon": lon,
             "radius": radius,
         },
     }
+    if page_size is not None:
+        payload["pageSize"] = page_size
+    if row_start is not None:
+        payload["rowStart"] = row_start
+    return payload
 
 
 def _run_in_new_event_loop(awaitable: Awaitable[T]) -> T:
@@ -954,8 +959,9 @@ class ESSDiveClient:
 
     async def search_datasets(
         self,
-        row_start: int = 1,
-        page_size: int = 25,
+        row_start: Optional[int] = None,
+        page_size: Optional[int] = None,
+        cursor: Optional[str] = None,
         is_public: Optional[bool] = None,
         creator: Optional[str] = None,
         provider_name: Optional[str] = None,
@@ -974,8 +980,9 @@ class ESSDiveClient:
         Search for datasets using the ESS-DIVE API.
 
         Args:
-            row_start: The row number to start on (for pagination)
+            row_start: Legacy row number to start on (for pagination)
             page_size: Number of results per page (max 100)
+            cursor: Opaque cursor for follow-up pages of search results
             is_public: If True, only return public packages
             creator: Filter by dataset creator
             provider_name: Filter by dataset project/provider
@@ -996,11 +1003,14 @@ class ESSDiveClient:
         Examples:
             await client.search_datasets(text="soil carbon", page_size=5, is_public=True)
             await client.search_datasets(provider_name="NGEE Arctic", row_start=1, page_size=10)
+            await client.search_datasets(text="soil carbon", cursor="opaque-cursor")
             await client.search_datasets(begin_date="2020", end_date="2021-06")
             await client.search_datasets(text="soil carbon", sort="name:asc")
             await client.search_datasets(bbox=[34.0, -119.0, 35.0, -117.0])
         """
         params: Dict[str, Any] = {}
+        effective_row_start = 1 if row_start is None else row_start
+        effective_page_size = 25 if page_size is None else page_size
         normalized_bbox = _validate_dataset_search_spatial_params(
             bbox=bbox,
             lat=lat,
@@ -1008,9 +1018,14 @@ class ESSDiveClient:
             radius=radius,
         )
 
-        # Always include pagination parameters
-        params["rowStart"] = row_start
-        params["pageSize"] = page_size
+        # Cursor pagination supersedes legacy rowStart pagination.
+        if cursor:
+            params["cursor"] = cursor
+            if page_size is not None:
+                params["pageSize"] = page_size
+        else:
+            params["rowStart"] = effective_row_start
+            params["pageSize"] = effective_page_size
 
         # Add optional parameters if provided
         if is_public is not None:
@@ -1054,8 +1069,9 @@ class ESSDiveClient:
                         "converting to an empty result set"
                     )
                     return _empty_dataset_search_result(
-                        row_start=row_start,
-                        page_size=page_size,
+                        row_start=None if cursor else effective_row_start,
+                        page_size=page_size if cursor else effective_page_size,
+                        cursor=cursor,
                         is_public=is_public,
                         creator=creator,
                         provider_name=provider_name,
@@ -1220,6 +1236,7 @@ class ESSDiveClient:
         query = results.get("query", {}) if isinstance(
             results.get("query"), dict) else {}
         sort_value = query.get("sort")
+        has_cursor_pagination = "nextCursor" in results or "previousCursor" in results
 
         if filtering:
             native_total = filtering.get("native_total")
@@ -1236,6 +1253,11 @@ class ESSDiveClient:
 
         if sort_value:
             header += f"Sort: {sort_value}\n\n"
+        if has_cursor_pagination:
+            header += (
+                f"Pagination: previousCursor={results.get('previousCursor') or 'None'}; "
+                f"nextCursor={results.get('nextCursor') or 'None'}\n\n"
+            )
 
         if format_type == "summary":
             summary = header
@@ -1789,8 +1811,9 @@ def main():
         file_format: Optional[Union[str, List[str]]] = None,
         file_name: Optional[Union[str, List[str]]] = None,
         file_url: Optional[Union[str, List[str]]] = None,
-        row_start: int = 1,
-        page_size: int = 25,
+        cursor: Optional[str] = None,
+        row_start: Optional[int] = None,
+        page_size: Optional[int] = None,
         format: str = "summary",
     ) -> str:
         """
@@ -1819,8 +1842,9 @@ def main():
             file_format: Local post-filter on distribution encodingFormat values
             file_name: Local post-filter on distribution file names
             file_url: Local post-filter on distribution content URLs
-            row_start: The row number to start on (for pagination)
-            page_size: Number of results per page
+            cursor: Opaque cursor for a follow-up page of search results
+            row_start: Legacy row number to start on when not using cursor pagination
+            page_size: Number of results per page; omit on cursor follow-up unless it matches the cursor
             format: Format of the results (summary, detailed, raw)
 
         Examples:
@@ -1828,6 +1852,7 @@ def main():
             search-datasets with creator="Smith" and provider_name="NGEE Arctic"
             search-datasets with begin_date="2020" and end_date="2021-06" and format="detailed"
             search-datasets with query="soil carbon" and sort="name:asc"
+            search-datasets with query="BIONTE" and cursor="opaque-cursor"
             search-datasets with bbox=[34.0, -119.0, 35.0, -117.0]
             search-datasets with lat=37.7749 and lon=-122.4194 and radius=5000
             search-datasets with query="snowmelt" and creator_affiliation="Pennsylvania"
@@ -1837,13 +1862,14 @@ def main():
             Formatted search results
         """
         LOGGER.debug(
-            "Tool search-datasets called query=%r creator=%r provider_name=%r begin_date=%r end_date=%r sort=%r bbox=%r lat=%r lon=%r radius=%r local_filters=%r row_start=%s page_size=%s format=%s",
+            "Tool search-datasets called query=%r creator=%r provider_name=%r begin_date=%r end_date=%r sort=%r cursor=%r bbox=%r lat=%r lon=%r radius=%r local_filters=%r row_start=%s page_size=%s format=%s",
             query,
             creator,
             provider_name,
             begin_date,
             end_date,
             sort,
+            cursor,
             bbox,
             lat,
             lon,
@@ -1894,6 +1920,7 @@ def main():
             result = await client.search_datasets(
                 row_start=row_start,
                 page_size=page_size,
+                cursor=cursor,
                 is_public=_default_dataset_search_is_public(client.api_token),
                 creator=creator,
                 provider_name=provider_name,
@@ -1937,6 +1964,7 @@ def main():
                         "begin_date": begin_date,
                         "end_date": end_date,
                         "sort": sort,
+                        "cursor": cursor,
                         "bbox": bbox,
                         "lat": lat,
                         "lon": lon,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -13,11 +13,11 @@ _FIXTURES_PATH = Path(__file__).parent / "fixtures" / "api_examples.json"
 
 @pytest.fixture(scope="session")
 def essdive_api_token() -> str:
-    """Return ESS-DIVE API token or skip ESS-DIVE integration tests."""
+    """Return ESS-DIVE API token or skip authenticated ESS-DIVE integration tests."""
     token = os.getenv("ESSDIVE_API_TOKEN")
     if not token:
         pytest.skip(
-            "ESSDIVE_API_TOKEN is required for ESS-DIVE integration tests."
+            "ESSDIVE_API_TOKEN is required for authenticated ESS-DIVE integration tests."
         )
     return token
 

--- a/tests/integration/test_api_integration.py
+++ b/tests/integration/test_api_integration.py
@@ -145,6 +145,39 @@ async def test_search_public_datasets_live_sorting_without_token():
     assert names == sorted(names, key=str.casefold)
 
 
+@pytest.mark.asyncio
+async def test_search_public_datasets_live_cursor_pagination_without_token():
+    """Search results should support cursor-based pagination without authentication."""
+    client = ESSDiveClient()
+
+    first_page = await client.search_datasets(
+        text="BIONTE",
+        is_public=True,
+        page_size=2,
+        sort="name:asc",
+    )
+
+    next_cursor = first_page.get("nextCursor")
+    if not next_cursor:
+        pytest.skip("Search fixture no longer spans multiple result pages.")
+
+    second_page = await client.search_datasets(
+        text="BIONTE",
+        is_public=True,
+        sort="name:asc",
+        cursor=next_cursor,
+    )
+
+    first_ids = {item["id"] for item in first_page["result"]}
+    second_ids = {item["id"] for item in second_page["result"]}
+
+    assert second_page["previousCursor"] is not None
+    assert second_ids
+    assert second_ids.isdisjoint(first_ids)
+    assert second_page["query"]["sort"] == "name:asc"
+    assert second_page["query"]["text"] == "BIONTE"
+
+
 def test_doi_to_essdive_id_live_without_token(
     essdive_dataset_examples: list[dict[str, str]],
 ):

--- a/tests/integration/test_api_integration.py
+++ b/tests/integration/test_api_integration.py
@@ -122,6 +122,26 @@ async def test_search_public_datasets_live_without_token(
     assert str(example["expected_id"]) in {item["id"] for item in response["result"]}
 
 
+@pytest.mark.asyncio
+async def test_search_public_datasets_live_sorting_without_token():
+    """Anonymous callers should be able to request supported API sort orders."""
+    client = ESSDiveClient()
+
+    response = await client.search_datasets(
+        text="BIONTE",
+        is_public=True,
+        page_size=3,
+        sort="name:asc",
+    )
+
+    assert isinstance(response, dict)
+    assert response["query"]["sort"] == "name:asc"
+    assert len(response["result"]) >= 2
+
+    names = [item["dataset"]["name"] for item in response["result"]]
+    assert names == sorted(names, key=str.casefold)
+
+
 def test_doi_to_essdive_id_live_without_token(
     essdive_dataset_examples: list[dict[str, str]],
 ):

--- a/tests/integration/test_api_integration.py
+++ b/tests/integration/test_api_integration.py
@@ -54,6 +54,49 @@ async def test_get_public_dataset_by_id_live_without_token(
 
 
 @pytest.mark.asyncio
+async def test_get_dataset_versions_live_without_token(
+    essdive_dataset_examples: list[dict[str, str]],
+):
+    """Public dataset version history should be retrievable without authentication."""
+    client = ESSDiveClient()
+    example = essdive_dataset_examples[0]
+
+    response = await client.get_dataset_versions(example["doi"], page_size=2)
+
+    assert isinstance(response, dict)
+    assert response["total"] >= 1
+    assert response["pageSize"] == 2
+    assert isinstance(response["result"], list)
+    assert len(response["result"]) >= 1
+    assert all(item["dataset"]["@id"] == example["doi"] for item in response["result"])
+    assert all(item.get("viewUrl") for item in response["result"])
+
+
+@pytest.mark.asyncio
+async def test_get_dataset_versions_live_cursor_pagination_without_token(
+    essdive_dataset_examples: list[dict[str, str]],
+):
+    """Version-history cursors should fetch a later page of older versions."""
+    client = ESSDiveClient()
+    example = essdive_dataset_examples[0]
+
+    first_page = await client.get_dataset_versions(example["doi"], page_size=2)
+    next_cursor = first_page.get("nextCursor")
+    if not next_cursor:
+        pytest.skip("Fixture dataset no longer spans multiple version pages.")
+
+    second_page = await client.get_dataset_versions(example["doi"], cursor=next_cursor)
+
+    first_ids = {item["id"] for item in first_page["result"]}
+    second_ids = {item["id"] for item in second_page["result"]}
+
+    assert second_page["previousCursor"] is not None
+    assert second_ids
+    assert second_ids.isdisjoint(first_ids)
+    assert all(item["dataset"]["@id"] == example["doi"] for item in second_page["result"])
+
+
+@pytest.mark.asyncio
 async def test_search_public_datasets_live_without_token(
     essdive_search_examples: list[dict[str, Any]],
 ):

--- a/tests/integration/test_api_integration.py
+++ b/tests/integration/test_api_integration.py
@@ -39,6 +39,58 @@ def _download_prefix(url: str, bytes_to_read: int) -> tuple[int, str, bytes]:
 
 
 @pytest.mark.asyncio
+async def test_get_public_dataset_by_id_live_without_token(
+    essdive_dataset_examples: list[dict[str, str]],
+):
+    """Public ESS-DIVE datasets should be retrievable without authentication."""
+    client = ESSDiveClient()
+    example = essdive_dataset_examples[0]
+
+    response = await client.get_dataset(example["id"])
+
+    assert response["id"] == example["id"]
+    assert response.get("isPublic") is True
+    assert response.get("viewUrl")
+
+
+@pytest.mark.asyncio
+async def test_search_public_datasets_live_without_token(
+    essdive_search_examples: list[dict[str, Any]],
+):
+    """Anonymous callers should be able to search public ESS-DIVE datasets."""
+    client = ESSDiveClient()
+    example = essdive_search_examples[0]
+
+    response = await client.search_datasets(
+        text=str(example["query"]),
+        begin_date=example.get("begin_date"),
+        end_date=example.get("end_date"),
+        bbox=example.get("bbox"),
+        lat=example.get("lat"),
+        lon=example.get("lon"),
+        radius=example.get("radius"),
+        is_public=True,
+        page_size=int(example.get("page_size", 10)),
+    )
+
+    assert isinstance(response, dict)
+    assert response["total"] > 0
+    assert isinstance(response["result"], list)
+    assert str(example["expected_id"]) in {item["id"] for item in response["result"]}
+
+
+def test_doi_to_essdive_id_live_without_token(
+    essdive_dataset_examples: list[dict[str, str]],
+):
+    """Public DOI resolution should work without authentication."""
+    example = essdive_dataset_examples[0]
+
+    resolved_id = doi_to_essdive_id(example["doi"])
+
+    assert resolved_id == example["id"]
+
+
+@pytest.mark.asyncio
 async def test_get_dataset_by_id_live(
     essdive_api_token: str,
     essdive_dataset_examples: list[dict[str, str]],

--- a/tests/integration/test_api_integration.py
+++ b/tests/integration/test_api_integration.py
@@ -68,7 +68,8 @@ async def test_get_dataset_versions_live_without_token(
     assert response["pageSize"] == 2
     assert isinstance(response["result"], list)
     assert len(response["result"]) >= 1
-    assert all(item["dataset"]["@id"] == example["doi"] for item in response["result"])
+    assert all(item["dataset"]["@id"] == example["doi"]
+               for item in response["result"])
     assert all(item.get("viewUrl") for item in response["result"])
 
 
@@ -93,7 +94,8 @@ async def test_get_dataset_versions_live_cursor_pagination_without_token(
     assert second_page["previousCursor"] is not None
     assert second_ids
     assert second_ids.isdisjoint(first_ids)
-    assert all(item["dataset"]["@id"] == example["doi"] for item in second_page["result"])
+    assert all(item["dataset"]["@id"] == example["doi"]
+               for item in second_page["result"])
 
 
 @pytest.mark.asyncio
@@ -119,7 +121,8 @@ async def test_search_public_datasets_live_without_token(
     assert isinstance(response, dict)
     assert response["total"] > 0
     assert isinstance(response["result"], list)
-    assert str(example["expected_id"]) in {item["id"] for item in response["result"]}
+    assert str(example["expected_id"]) in {
+        item["id"] for item in response["result"]}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_api_unit.py
+++ b/tests/unit/test_api_unit.py
@@ -415,6 +415,60 @@ class TestESSDiveClient:
             assert params["sort"] == "dateUploaded:desc,authorLastName:asc"
 
     @pytest.mark.asyncio
+    async def test_search_datasets_cursor_omits_legacy_row_start_and_default_page_size(self):
+        """Cursor follow-up search requests should not force rowStart or pageSize defaults."""
+        client = ESSDiveClient(api_token="test_token")
+
+        mock_response_obj = Mock()
+        mock_response_obj.json.return_value = {"result": [], "total": 0}
+        mock_response_obj.raise_for_status = Mock()
+
+        with patch("essdive_mcp.main.httpx.AsyncClient") as mock_client_class:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get = AsyncMock(
+                return_value=mock_response_obj)
+            mock_client_instance.__aenter__.return_value = mock_client_instance
+            mock_client_instance.__aexit__.return_value = None
+            mock_client_class.return_value = mock_client_instance
+
+            await client.search_datasets(
+                text="soil carbon",
+                cursor="cursor-123",
+                sort="name:asc",
+            )
+
+            params = mock_client_instance.get.call_args.kwargs["params"]
+            assert params == {"cursor": "cursor-123", "text": "soil carbon", "sort": "name:asc"}
+
+    @pytest.mark.asyncio
+    async def test_search_datasets_cursor_includes_explicit_matching_page_size(self):
+        """Cursor follow-up requests may include pageSize only when explicitly supplied."""
+        client = ESSDiveClient(api_token="test_token")
+
+        mock_response_obj = Mock()
+        mock_response_obj.json.return_value = {"result": [], "total": 0}
+        mock_response_obj.raise_for_status = Mock()
+
+        with patch("essdive_mcp.main.httpx.AsyncClient") as mock_client_class:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get = AsyncMock(
+                return_value=mock_response_obj)
+            mock_client_instance.__aenter__.return_value = mock_client_instance
+            mock_client_instance.__aexit__.return_value = None
+            mock_client_class.return_value = mock_client_instance
+
+            await client.search_datasets(
+                text="soil carbon",
+                cursor="cursor-123",
+                page_size=10,
+            )
+
+            params = mock_client_instance.get.call_args.kwargs["params"]
+            assert params["cursor"] == "cursor-123"
+            assert params["pageSize"] == 10
+            assert "rowStart" not in params
+
+    @pytest.mark.asyncio
     async def test_search_datasets_accepts_string_bbox(self):
         """bbox may be provided in the API's comma-delimited string format."""
         client = ESSDiveClient(api_token="test_token")
@@ -884,6 +938,27 @@ class TestFormatResults:
         formatted = client.format_results(results, "summary")
 
         assert "Sort: name:asc" in formatted
+
+    def test_format_results_summary_includes_cursor_pagination(self):
+        """Summary format should expose next/previous cursors when present."""
+        client = ESSDiveClient()
+
+        results = {
+            "result": [
+                {
+                    "id": "ds1",
+                    "dataset": {"name": "Dataset 1", "datePublished": "2024-01-01"},
+                    "viewUrl": "https://example.com/ds1",
+                }
+            ],
+            "total": 10,
+            "nextCursor": "next-cursor",
+            "previousCursor": None,
+        }
+
+        formatted = client.format_results(results, "summary")
+
+        assert "Pagination: previousCursor=None; nextCursor=next-cursor" in formatted
 
     def test_format_results_detailed_with_extra_metadata(self):
         """Detailed format should surface richer dataset metadata when present."""

--- a/tests/unit/test_api_unit.py
+++ b/tests/unit/test_api_unit.py
@@ -19,6 +19,7 @@ from essdive_mcp.main import (
     search_project_portals,
     _dataset_matches_local_filters,
     _apply_local_dataset_filters,
+    _default_dataset_search_is_public,
 )
 import pytest
 import os
@@ -69,6 +70,18 @@ class TestBooleanHelpers:
         assert not _is_truthy("false")
         assert not _is_truthy("")
         assert not _is_truthy(None)
+
+
+class TestDatasetSearchVisibilityDefaults:
+    """Tests for default public/private search visibility behavior."""
+
+    def test_anonymous_search_defaults_to_public_only(self):
+        """Anonymous search should keep the existing public-only behavior."""
+        assert _default_dataset_search_is_public(None) is True
+
+    def test_authenticated_search_allows_private_matches(self):
+        """Authenticated search should not force the API back to public-only."""
+        assert _default_dataset_search_is_public("token-123") is None
 
 
 class TestToolErrorPayload:

--- a/tests/unit/test_api_unit.py
+++ b/tests/unit/test_api_unit.py
@@ -132,7 +132,8 @@ class TestProjectPortalReferences:
         result = search_project_portals("East River", limit=5)
 
         assert result["count"] >= 1
-        assert any("East River" in item["name"] or "East River" in " ".join(item["aliases"]) for item in result["results"])
+        assert any("East River" in item["name"] or "East River" in " ".join(
+            item["aliases"]) for item in result["results"])
 
     def test_search_project_portals_without_query_lists_entries(self):
         """Listing without a query should return a bounded set of entries."""
@@ -453,7 +454,8 @@ class TestESSDiveClient:
         )
         mock_response_obj = Mock()
         mock_response_obj.status_code = 404
-        mock_response_obj.json.return_value = {"detail": "No datasets were found."}
+        mock_response_obj.json.return_value = {
+            "detail": "No datasets were found."}
         mock_response_obj.raise_for_status.side_effect = httpx.HTTPStatusError(
             "404 not found",
             request=request,
@@ -688,7 +690,8 @@ class TestESSDiveClient:
 
         with patch("essdive_mcp.main.httpx.AsyncClient") as mock_client_class:
             mock_client_instance = AsyncMock()
-            mock_client_instance.get = AsyncMock(return_value=mock_response_obj)
+            mock_client_instance.get = AsyncMock(
+                return_value=mock_response_obj)
             mock_client_instance.__aenter__.return_value = mock_client_instance
             mock_client_instance.__aexit__.return_value = None
             mock_client_class.return_value = mock_client_instance
@@ -711,7 +714,8 @@ class TestESSDiveClient:
 
         with patch("essdive_mcp.main.httpx.AsyncClient") as mock_client_class:
             mock_client_instance = AsyncMock()
-            mock_client_instance.get = AsyncMock(return_value=mock_response_obj)
+            mock_client_instance.get = AsyncMock(
+                return_value=mock_response_obj)
             mock_client_instance.__aenter__.return_value = mock_client_instance
             mock_client_instance.__aexit__.return_value = None
             mock_client_class.return_value = mock_client_instance

--- a/tests/unit/test_api_unit.py
+++ b/tests/unit/test_api_unit.py
@@ -364,6 +364,31 @@ class TestESSDiveClient:
             assert params["bbox"] == "34.0,-119.0,35.0,-117.0"
 
     @pytest.mark.asyncio
+    async def test_search_datasets_includes_sort_param(self):
+        """Sort directives should be forwarded to the API."""
+        client = ESSDiveClient(api_token="test_token")
+
+        mock_response_obj = Mock()
+        mock_response_obj.json.return_value = {"result": [], "total": 0}
+        mock_response_obj.raise_for_status = Mock()
+
+        with patch("essdive_mcp.main.httpx.AsyncClient") as mock_client_class:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get = AsyncMock(
+                return_value=mock_response_obj)
+            mock_client_instance.__aenter__.return_value = mock_client_instance
+            mock_client_instance.__aexit__.return_value = None
+            mock_client_class.return_value = mock_client_instance
+
+            await client.search_datasets(
+                text="soil carbon",
+                sort="dateUploaded:desc,authorLastName:asc",
+            )
+
+            params = mock_client_instance.get.call_args.kwargs["params"]
+            assert params["sort"] == "dateUploaded:desc,authorLastName:asc"
+
+    @pytest.mark.asyncio
     async def test_search_datasets_accepts_string_bbox(self):
         """bbox may be provided in the API's comma-delimited string format."""
         client = ESSDiveClient(api_token="test_token")
@@ -810,6 +835,26 @@ class TestFormatResults:
 
         assert "after local metadata filtering" in formatted
         assert "from 12 native matches" in formatted
+
+    def test_format_results_summary_includes_effective_sort(self):
+        """Summary format should surface the effective API sort order."""
+        client = ESSDiveClient()
+
+        results = {
+            "result": [
+                {
+                    "id": "ds1",
+                    "dataset": {"name": "Dataset 1", "datePublished": "2024-01-01"},
+                    "viewUrl": "https://example.com/ds1",
+                }
+            ],
+            "total": 1,
+            "query": {"sort": "name:asc"},
+        }
+
+        formatted = client.format_results(results, "summary")
+
+        assert "Sort: name:asc" in formatted
 
     def test_format_results_detailed_with_extra_metadata(self):
         """Detailed format should surface richer dataset metadata when present."""

--- a/tests/unit/test_api_unit.py
+++ b/tests/unit/test_api_unit.py
@@ -634,6 +634,69 @@ class TestESSDiveClient:
             assert result["dataset"]["name"] == "Dataset 1"
 
     @pytest.mark.asyncio
+    async def test_get_dataset_versions(self):
+        """Test get_dataset_versions method."""
+        client = ESSDiveClient(api_token="test_token")
+
+        mock_response = {
+            "total": 2,
+            "pageSize": 2,
+            "nextCursor": "next-cursor",
+            "previousCursor": None,
+            "result": [
+                {
+                    "id": "ds-v2",
+                    "viewUrl": "https://example.org/ds-v2",
+                    "dateUploaded": "2026-01-01T00:00:00Z",
+                    "dataset": {
+                        "name": "Dataset 1 v2",
+                        "@id": "doi:10.1234/example",
+                        "datePublished": "2026",
+                    },
+                }
+            ],
+        }
+
+        mock_response_obj = Mock()
+        mock_response_obj.json.return_value = mock_response
+        mock_response_obj.raise_for_status = Mock()
+
+        with patch("essdive_mcp.main.httpx.AsyncClient") as mock_client_class:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get = AsyncMock(return_value=mock_response_obj)
+            mock_client_instance.__aenter__.return_value = mock_client_instance
+            mock_client_instance.__aexit__.return_value = None
+            mock_client_class.return_value = mock_client_instance
+
+            result = await client.get_dataset_versions("doi:10.1234/example", page_size=2)
+
+            assert result["total"] == 2
+            assert result["result"][0]["id"] == "ds-v2"
+            params = mock_client_instance.get.call_args.kwargs["params"]
+            assert params["pageSize"] == 2
+
+    @pytest.mark.asyncio
+    async def test_get_dataset_versions_omits_page_size_when_unset(self):
+        """Cursor follow-up requests should not force a default page size."""
+        client = ESSDiveClient(api_token="test_token")
+
+        mock_response_obj = Mock()
+        mock_response_obj.json.return_value = {"total": 0, "result": []}
+        mock_response_obj.raise_for_status = Mock()
+
+        with patch("essdive_mcp.main.httpx.AsyncClient") as mock_client_class:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get = AsyncMock(return_value=mock_response_obj)
+            mock_client_instance.__aenter__.return_value = mock_client_instance
+            mock_client_instance.__aexit__.return_value = None
+            mock_client_class.return_value = mock_client_instance
+
+            await client.get_dataset_versions("doi:10.1234/example", cursor="cursor-123")
+
+            params = mock_client_instance.get.call_args.kwargs["params"]
+            assert params == {"cursor": "cursor-123"}
+
+    @pytest.mark.asyncio
     async def test_get_dataset_status(self):
         """Test get_dataset_status method."""
         client = ESSDiveClient(api_token="test_token")
@@ -800,6 +863,81 @@ class TestFormatResults:
         formatted = client.format_results(results, "summary")
 
         assert "No results found" in formatted
+
+    def test_format_dataset_versions_raw(self):
+        """Raw version format should return unchanged results."""
+        client = ESSDiveClient()
+        results = {"result": [{"id": "ds-v2"}], "total": 1}
+
+        formatted = client.format_dataset_versions(results, "raw")
+
+        assert formatted == results
+
+    def test_format_dataset_versions_summary(self):
+        """Summary version format should include pagination cursors and version IDs."""
+        client = ESSDiveClient()
+
+        results = {
+            "total": 2,
+            "pageSize": 2,
+            "nextCursor": "next-cursor",
+            "previousCursor": None,
+            "result": [
+                {
+                    "id": "ds-v2",
+                    "viewUrl": "https://example.com/ds-v2",
+                    "dateUploaded": "2026-01-01T00:00:00Z",
+                    "dataset": {
+                        "name": "Dataset 1 v2",
+                        "@id": "doi:10.1234/example",
+                        "datePublished": "2026",
+                    },
+                }
+            ],
+        }
+
+        formatted = client.format_dataset_versions(results, "summary")
+
+        assert isinstance(formatted, str)
+        assert "Found 2 visible dataset versions" in formatted
+        assert "nextCursor: next-cursor" in formatted
+        assert "ds-v2" in formatted
+
+    def test_format_dataset_versions_detailed(self):
+        """Detailed version format should surface citation and neighbor links."""
+        client = ESSDiveClient()
+
+        results = {
+            "total": 1,
+            "pageSize": 1,
+            "nextCursor": None,
+            "previousCursor": None,
+            "result": [
+                {
+                    "id": "ds-v2",
+                    "viewUrl": "https://example.com/ds-v2",
+                    "url": "https://api.example.com/packages/ds-v2",
+                    "next": "https://api.example.com/packages/ds-v3",
+                    "previous": "https://api.example.com/packages/ds-v1",
+                    "dateUploaded": "2026-01-01T00:00:00Z",
+                    "dateModified": "2026-01-02T00:00:00Z",
+                    "isPublic": True,
+                    "citation": "Example Citation",
+                    "dataset": {
+                        "name": "Dataset 1 v2",
+                        "@id": "doi:10.1234/example",
+                        "datePublished": "2026",
+                        "description": "Example description",
+                    },
+                }
+            ],
+        }
+
+        formatted = client.format_dataset_versions(results, "detailed")
+
+        assert "Example Citation" in formatted
+        assert "Newer Version URL" in formatted
+        assert "Older Version URL" in formatted
 
 
 class TestNormalizeDoi:

--- a/tests/unit/test_api_unit.py
+++ b/tests/unit/test_api_unit.py
@@ -20,6 +20,7 @@ from essdive_mcp.main import (
     _dataset_matches_local_filters,
     _apply_local_dataset_filters,
     _default_dataset_search_is_public,
+    _resolve_startup_api_token,
 )
 import pytest
 import os
@@ -52,6 +53,17 @@ class TestGetApiKey:
         """Missing token config should be allowed for anonymous public access."""
         with patch.dict(os.environ, {}, clear=True):
             assert get_api_key(None) is None
+
+    def test_resolve_startup_api_token_warns_and_falls_back_on_bad_token_file(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        """Unreadable token files should warn and fall back to anonymous mode."""
+        with caplog.at_level("WARNING", logger="essdive_mcp"):
+            resolved = _resolve_startup_api_token(token_file="/tmp/definitely-missing")
+
+        assert resolved is None
+        assert "Could not read ESS-DIVE token file" in caplog.text
+        assert "Starting without ESS-DIVE auth" in caplog.text
 
 
 class TestBooleanHelpers:

--- a/tests/unit/test_api_unit.py
+++ b/tests/unit/test_api_unit.py
@@ -47,11 +47,10 @@ class TestGetApiKey:
             result = get_api_key("param_key")
             assert result == "param_key"
 
-    def test_get_api_key_missing_raises_error(self):
-        """Test that missing API key raises ValueError."""
+    def test_get_api_key_missing_returns_none(self):
+        """Missing token config should be allowed for anonymous public access."""
         with patch.dict(os.environ, {}, clear=True):
-            with pytest.raises(ValueError, match="ESS-DIVE API key is required"):
-                get_api_key(None)
+            assert get_api_key(None) is None
 
 
 class TestBooleanHelpers:

--- a/uv.lock
+++ b/uv.lock
@@ -408,7 +408,7 @@ wheels = [
 
 [[package]]
 name = "essdive-mcp"
-version = "0.2.6"
+version = "0.2.7"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Updates to enable compatibility with [v2.4.0](https://github.com/ess-dive/essdive-package-service/releases/tag/v2.4.0) of the ESS-DIVE Dataset API, including:
* Anonymous dataset search (can use search w/o API key, but API key can still be specified to search and access private datasets)
* Cursor-based dataset pagination
* Get and sort by dataset version
* Sort datasets by other fields, like name or date uploaded

Changes impact both MCP tools and Skills.