### PR TITLE
Cover more of the dataset API; expand pagination handling

### DIFF
--- a/.agents/skills/essdive-datasets/SKILL.md
+++ b/.agents/skills/essdive-datasets/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: essdive-datasets
-description: Search ESS-DIVE datasets, fetch metadata/version history/permissions, and parse FLMD via MCP tools.
+description: Search ESS-DIVE datasets, fetch metadata/version history/status/permissions, and parse FLMD via MCP tools.
 ---
 
 # Setup (once)
@@ -49,6 +49,7 @@ claude mcp add --transport stdio essdive-mcp -- uv run python ./src/essdive_mcp/
 - `search-datasets`
 - `get-dataset`
 - `get-dataset-versions`
+- `get-dataset-status`
 - `get-dataset-permissions`
 - `parse-flmd-file`
 - `lookup-project-portal`
@@ -155,6 +156,19 @@ Get detailed metadata for a dataset:
 get-dataset with id="ess-dive-9ea5fe57db73c90-20241024T093714082510"
 ```
 
+Return the raw dataset payload when you need exact top-level API fields such as
+`isPublic`, `dateUploaded`, `dateModified`, `citation`, or `viewUrl`:
+
+```
+get-dataset with id="doi:10.15485/2529445" and format="raw"
+```
+
+Check publication/workflow status for a dataset:
+
+```
+get-dataset-status with id="ess-dive-f78cb03d11550da-20260309T160313214"
+```
+
 List version history from newest to oldest:
 
 ```
@@ -194,12 +208,17 @@ coords-to-map-links with bbox=[38.9187, -106.9532, 38.9263, -106.9451]
 ## Notes
 
 - Use `format="summary"` for compact results, or `format="detailed"` for full metadata.
+- Use `get-dataset-status` when the user asks for dataset status. Do not infer status from `get-dataset`.
+- If the user asks for the status of multiple datasets, call `get-dataset-status` once per dataset identifier and summarize the results.
+- `get-dataset-status` may require an ESS-DIVE API token and dataset access. If an anonymous call fails, explain that status is auth-gated.
+- `get-dataset` supports `format="raw"` when you need the exact response fields, including top-level `isPublic`.
 - `page_size` max is 100.
 - `cursor` is the preferred way to page through search results. `row_start` is still supported for compatibility but is legacy.
-- For cursor follow-up searches, reuse the same search filters and omit `page_size` unless you know it matches the cursor's encoded page size.
+- Search and version responses include an integer `total` plus `nextCursor` and `previousCursor` when pagination is available.
+- For cursor follow-up searches, omit `cursor` on the first request, then pass the returned `nextCursor` or `previousCursor` value unchanged on later requests. Reuse the same search filters and omit `page_size` unless you know it matches the cursor's encoded page size.
 - `sort` accepts comma-separated `field:direction` clauses. Supported fields: `name`, `dateUploaded`, `authorLastName`. Supported directions: `asc`, `desc`.
 - `get-dataset-versions` lists visible versions from newest to oldest and supports cursor pagination.
-- For `get-dataset-versions`, omit `page_size` on cursor follow-up calls unless you know it matches the cursor's encoded page size.
+- For `get-dataset-versions`, omit `page_size` on cursor follow-up calls unless you know it matches the cursor's encoded page size. As with search, pass returned cursor values unchanged.
 - `bbox` uses `[min_lat, min_lon, max_lat, max_lon]` ordering and can also be passed as a comma-delimited string.
 - Point search requires `lat`, `lon`, and `radius` together. Do not combine point search with `bbox`.
 - Native ESS-DIVE `/packages` filters include `query`/`text`, `creator`, `provider_name`, `date_published`, `begin_date`, `end_date`, `keywords`, `sort`, `bbox`, and `lat`/`lon`/`radius`.

--- a/.agents/skills/essdive-datasets/SKILL.md
+++ b/.agents/skills/essdive-datasets/SKILL.md
@@ -47,8 +47,12 @@ claude mcp add --transport stdio essdive-mcp -- uv run python ./src/essdive_mcp/
 # Tools
 
 - `search-datasets`
+- `next-search-page`
+- `previous-search-page`
 - `get-dataset`
 - `get-dataset-versions`
+- `next-dataset-versions-page`
+- `previous-dataset-versions-page`
 - `get-dataset-status`
 - `get-dataset-permissions`
 - `parse-flmd-file`
@@ -95,6 +99,30 @@ Then use the returned `nextCursor` or `previousCursor`:
 
 ```
 search-datasets with query="BIONTE" and sort="name:asc" and cursor="PASTE_NEXT_OR_PREVIOUS_CURSOR_HERE"
+```
+
+For conversational pagination, prefer the stateful MCP wrapper instead of exposing cursors:
+
+```
+next-search-page
+```
+
+Or go back:
+
+```
+previous-search-page
+```
+
+If you need direct access to the raw pagination metadata, request raw form:
+
+```
+search-datasets with query="BIONTE" and sort="name:asc" and page_size=2 and format="raw"
+```
+
+Then summarize the page yourself, and if the user asks for the next page, rerun the same search with the returned `nextCursor` unchanged:
+
+```
+search-datasets with query="BIONTE" and sort="name:asc" and cursor="PASTE_NEXT_CURSOR_HERE" and format="raw"
 ```
 
 Filter by bounding box:
@@ -181,6 +209,22 @@ Follow a version-history cursor:
 get-dataset-versions with id="doi:10.15485/2529445" and cursor="PASTE_NEXT_OR_PREVIOUS_CURSOR_HERE"
 ```
 
+For conversational pagination through version history, prefer the stateful MCP wrappers:
+
+```
+next-dataset-versions-page
+```
+
+```
+previous-dataset-versions-page
+```
+
+If you need direct access to the raw pagination metadata, prefer raw mode on the first call:
+
+```
+get-dataset-versions with id="doi:10.15485/2529445" and page_size=2 and format="raw"
+```
+
 Check sharing permissions (requires token):
 
 ```
@@ -215,9 +259,12 @@ coords-to-map-links with bbox=[38.9187, -106.9532, 38.9263, -106.9451]
 - `page_size` max is 100.
 - `cursor` is the preferred way to page through search results. `row_start` is still supported for compatibility but is legacy.
 - Search and version responses include an integer `total` plus `nextCursor` and `previousCursor` when pagination is available.
+- `next-search-page` and `previous-search-page` page through the most recent `search-datasets` request without requiring the caller to pass cursors.
 - For cursor follow-up searches, omit `cursor` on the first request, then pass the returned `nextCursor` or `previousCursor` value unchanged on later requests. Reuse the same search filters and omit `page_size` unless you know it matches the cursor's encoded page size.
+- For a conversational “show me the next page” flow, prefer the stateful next/previous page tools. Use raw mode only when you explicitly need to inspect or persist the API cursor values.
 - `sort` accepts comma-separated `field:direction` clauses. Supported fields: `name`, `dateUploaded`, `authorLastName`. Supported directions: `asc`, `desc`.
 - `get-dataset-versions` lists visible versions from newest to oldest and supports cursor pagination.
+- `next-dataset-versions-page` and `previous-dataset-versions-page` page through the most recent `get-dataset-versions` request without requiring the caller to pass cursors.
 - For `get-dataset-versions`, omit `page_size` on cursor follow-up calls unless you know it matches the cursor's encoded page size. As with search, pass returned cursor values unchanged.
 - `bbox` uses `[min_lat, min_lon, max_lat, max_lon]` ordering and can also be passed as a comma-delimited string.
 - Point search requires `lat`, `lon`, and `radius` together. Do not combine point search with `bbox`.

--- a/README.md
+++ b/README.md
@@ -719,6 +719,9 @@ If your client supports direct tool calling, these examples map closely to the a
 search-datasets with query="wildfire recovery" and page_size=5
 search-datasets with query="BIONTE" and sort="name:asc" and page_size=3
 search-datasets with query="BIONTE" and sort="name:asc" and cursor="PASTE_NEXT_CURSOR_HERE"
+search-datasets with query="BIONTE" and sort="name:asc" and page_size=3 and format="raw"
+next-search-page
+previous-search-page
 search-datasets with begin_date="2020" and end_date="2021" and format="detailed"
 search-datasets with bbox=[38.9187, -106.9532, 38.9263, -106.9451]
 search-datasets with lat=38.8747 and lon=-76.5519 and radius=100
@@ -729,6 +732,8 @@ get-dataset with id="ess-dive-165671432ae620e-20250908T210722395"
 get-dataset with id="doi:10.15485/2529445" and format="raw"
 get-dataset-versions with id="doi:10.15485/2529445" and page_size=2
 get-dataset-versions with id="doi:10.15485/2529445" and cursor="PASTE_NEXT_CURSOR_HERE"
+next-dataset-versions-page
+previous-dataset-versions-page
 get-dataset-status with id="ess-dive-f78cb03d11550da-20260309T160313214"
 get-dataset-permissions with id="ess-dive-165671432ae620e-20250908T210722395"
 doi-to-essdive-id with doi="10.15485/2587853"
@@ -848,6 +853,8 @@ Examples:
 - `Use the essdive-datasets skill to find recent wildfire-related datasets and then fetch the metadata for the best match.`
 - `Use the essdive-datasets skill to search for BIONTE datasets sorted by name ascending and summarize the first three.`
 - `Use the essdive-datasets skill to search for BIONTE datasets, then continue to the next page with the returned cursor.`
+- `Use the essdive-datasets skill to search for BIONTE datasets, keep the pagination cursor, and show me the next page if I ask for more results.`
+- `Use the essdive-datasets skill to search for BIONTE datasets and then show me the next page without exposing the cursor values.`
 - `Use the essdive-datasets skill to list the version history for DOI 10.15485/2529445 and summarize the newest two versions.`
 - `Use the essdive-identifiers skill to normalize DOI https://doi.org/10.15485/2587853 and return the ESS-DIVE ID.`
 - `Use the essdeepdive skill to search for temperature fields and tell me which data file each result comes from.`
@@ -903,8 +910,12 @@ and the observed values range from 19.1 to 26.9 C.
 ### ESS-DIVE dataset tools
 
 - `search-datasets`
+- `next-search-page`
+- `previous-search-page`
 - `get-dataset`
 - `get-dataset-versions`
+- `next-dataset-versions-page`
+- `previous-dataset-versions-page`
 - `get-dataset-status`
 - `get-dataset-permissions`
 - `parse-flmd-file`

--- a/README.md
+++ b/README.md
@@ -726,8 +726,10 @@ search-datasets with query="East River" and creator_affiliation="Lawrence Berkel
 search-datasets with query="East River" and variable_measured="streamflow" and page_size=5
 search-datasets with query="East River" and funder="NASA" and page_size=5
 get-dataset with id="ess-dive-165671432ae620e-20250908T210722395"
+get-dataset with id="doi:10.15485/2529445" and format="raw"
 get-dataset-versions with id="doi:10.15485/2529445" and page_size=2
 get-dataset-versions with id="doi:10.15485/2529445" and cursor="PASTE_NEXT_CURSOR_HERE"
+get-dataset-status with id="ess-dive-f78cb03d11550da-20260309T160313214"
 get-dataset-permissions with id="ess-dive-165671432ae620e-20250908T210722395"
 doi-to-essdive-id with doi="10.15485/2587853"
 essdive-id-to-doi with essdive_id="ess-dive-165671432ae620e-20250908T210722395"
@@ -903,6 +905,7 @@ and the observed values range from 19.1 to 26.9 C.
 - `search-datasets`
 - `get-dataset`
 - `get-dataset-versions`
+- `get-dataset-status`
 - `get-dataset-permissions`
 - `parse-flmd-file`
 

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -126,6 +126,8 @@ To remove them:
 - `Use the essdive-datasets skill to find public ESS-DIVE datasets about wildfire recovery and summarize the top results.`
 - `Use the essdive-datasets skill to search for BIONTE datasets sorted by name ascending and summarize the first three.`
 - `Use the essdive-datasets skill to search for BIONTE datasets, then continue to the next page with the returned cursor.`
+- `Use the essdive-datasets skill to search for BIONTE datasets, keep the pagination cursor, and show me the next page if I ask for more results.`
+- `Use the essdive-datasets skill to search for BIONTE datasets and then show me the next page without exposing the cursor values.`
 - `Use the essdive-datasets skill to search for datasets inside the bounding box [38.9187, -106.9532, 38.9263, -106.9451] and summarize the matches.`
 - `Use the essdive-datasets skill to search for datasets within 100 meters of 38.8747, -76.5519 and summarize the matches.`
 - `Use the essdive-datasets skill to show the version history for DOI 10.15485/2529445 and summarize the newest two versions.`

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -129,6 +129,7 @@ To remove them:
 - `Use the essdive-datasets skill to search for datasets inside the bounding box [38.9187, -106.9532, 38.9263, -106.9451] and summarize the matches.`
 - `Use the essdive-datasets skill to search for datasets within 100 meters of 38.8747, -76.5519 and summarize the matches.`
 - `Use the essdive-datasets skill to show the version history for DOI 10.15485/2529445 and summarize the newest two versions.`
+- `Use the essdive-datasets skill to check the status of dataset ess-dive-f78cb03d11550da-20260309T160313214.`
 - `Use the essdive-datasets skill to search for East River datasets and then keep only results with Lawrence Berkeley Lab creator affiliations.`
 - `Use the essdive-datasets skill to search for East River datasets and then keep only results where variableMeasured includes streamflow.`
 

--- a/src/essdive_mcp/main.py
+++ b/src/essdive_mcp/main.py
@@ -373,6 +373,46 @@ def _organization_search_strings(organization: Dict[str, Any]) -> List[str]:
     return values
 
 
+def _summarize_provider(provider: Any) -> List[str]:
+    """Return readable provider summaries from dataset metadata."""
+    summaries: List[str] = []
+
+    for item in _as_list(provider):
+        if isinstance(item, dict):
+            name = str(item.get("name") or "").strip()
+            member = item.get("member")
+
+            member_labels: List[str] = []
+            for member_item in _as_list(member):
+                if isinstance(member_item, dict):
+                    member_name = _person_display_name(member_item)
+                    job_title = str(member_item.get("jobTitle") or "").strip()
+                    affiliation = str(member_item.get("affiliation") or "").strip()
+                    parts = [part for part in [member_name, job_title, affiliation] if part]
+                    if parts:
+                        member_labels.append(", ".join(parts))
+                else:
+                    text = str(member_item).strip()
+                    if text:
+                        member_labels.append(text)
+
+            label = name or ", ".join(_organization_search_strings(item))
+            if member_labels:
+                if label:
+                    label = f"{label} ({'; '.join(member_labels)})"
+                else:
+                    label = "; ".join(member_labels)
+            if label:
+                summaries.append(label)
+            continue
+
+        text = str(item).strip()
+        if text:
+            summaries.append(text)
+
+    return summaries
+
+
 def _distribution_search_strings(
     distribution: Any,
     *,
@@ -1240,6 +1280,7 @@ class ESSDiveClient:
             results.get("query"), dict) else {}
         sort_value = query.get("sort")
         has_cursor_pagination = "nextCursor" in results or "previousCursor" in results
+        user = results.get("user")
 
         if filtering:
             native_total = filtering.get("native_total")
@@ -1256,6 +1297,8 @@ class ESSDiveClient:
 
         if sort_value:
             header += f"Sort: {sort_value}\n\n"
+        if user:
+            header += f"User: {user}\n\n"
         if has_cursor_pagination:
             header += (
                 f"Pagination: previousCursor={results.get('previousCursor') or 'None'}; "
@@ -1272,7 +1315,13 @@ class ESSDiveClient:
                 if "isPublic" in dataset:
                     summary += f"   isPublic: {dataset.get('isPublic')}\n"
                 summary += f"   Published: {ds_data.get('datePublished', 'Unknown')}\n"
-                summary += f"   URL: {dataset.get('viewUrl', 'Unknown')}\n"
+                summary += f"   viewUrl: {dataset.get('viewUrl', 'Unknown')}\n"
+                if dataset.get("url"):
+                    summary += f"   url: {dataset.get('url')}\n"
+                if dataset.get("previous"):
+                    summary += f"   previous: {dataset.get('previous')}\n"
+                if dataset.get("next"):
+                    summary += f"   next: {dataset.get('next')}\n"
                 if i < len(datasets):
                     summary += "\n"
 
@@ -1292,7 +1341,13 @@ class ESSDiveClient:
                 if dataset.get("dateModified"):
                     detailed += f"   dateModified: {dataset.get('dateModified')}\n"
                 detailed += f"   Published: {ds_data.get('datePublished', 'Unknown')}\n"
-                detailed += f"   URL: {dataset.get('viewUrl', 'Unknown')}\n"
+                detailed += f"   viewUrl: {dataset.get('viewUrl', 'Unknown')}\n"
+                if dataset.get("url"):
+                    detailed += f"   url: {dataset.get('url')}\n"
+                if dataset.get("previous"):
+                    detailed += f"   previous: {dataset.get('previous')}\n"
+                if dataset.get("next"):
+                    detailed += f"   next: {dataset.get('next')}\n"
 
                 # Add description if available
                 description = ds_data.get("description", "")
@@ -1351,6 +1406,14 @@ class ESSDiveClient:
                 if license_value:
                     detailed += f"   License: {license_value}\n"
 
+                providers = _summarize_provider(ds_data.get("provider"))
+                if providers:
+                    detailed += f"   Provider: {'; '.join(providers)}\n"
+
+                awards = _as_string_list(ds_data.get("award"))
+                if awards:
+                    detailed += f"   Award: {', '.join(awards)}\n"
+
                 citation = dataset.get("citation")
                 if citation:
                     detailed += f"   citation: {citation}\n"
@@ -1394,6 +1457,12 @@ class ESSDiveClient:
             content += f"**doi**: {doi}\n"
         if result.get("viewUrl"):
             content += f"**viewUrl**: {result.get('viewUrl')}\n"
+        if result.get("url"):
+            content += f"**url**: {result.get('url')}\n"
+        if result.get("previous"):
+            content += f"**previous**: {result.get('previous')}\n"
+        if result.get("next"):
+            content += f"**next**: {result.get('next')}\n"
         if result.get("dateUploaded"):
             content += f"**dateUploaded**: {result.get('dateUploaded')}\n"
         if result.get("dateModified"):
@@ -1504,6 +1573,20 @@ class ESSDiveClient:
             content += "## License\n"
             content += f"{license_value}\n\n"
 
+        providers = _summarize_provider(dataset.get("provider"))
+        if providers:
+            content += "## Provider\n"
+            for provider in providers:
+                content += f"- {provider}\n"
+            content += "\n"
+
+        awards = _as_string_list(dataset.get("award"))
+        if awards:
+            content += "## Award\n"
+            for award in awards:
+                content += f"- {award}\n"
+            content += "\n"
+
         distribution = dataset.get("distribution", [])
         if distribution:
             content += "## Data Files\n"
@@ -1541,6 +1624,7 @@ class ESSDiveClient:
 
         versions = results["result"]
         total = results.get("total", 0)
+        user = results.get("user")
         header = (
             f"Found {total} visible dataset versions. "
             f"Showing {len(versions)} results from newest to oldest:\n"
@@ -1551,6 +1635,8 @@ class ESSDiveClient:
             f"  previousCursor: {results.get('previousCursor') or 'None'}\n"
             f"  nextCursor: {results.get('nextCursor') or 'None'}\n\n"
         )
+        if user:
+            header += f"User: {user}\n"
 
         if format_type == "summary":
             summary = header + pagination
@@ -1567,6 +1653,12 @@ class ESSDiveClient:
                 summary += f"   dateUploaded: {version.get('dateUploaded', 'Unknown')}\n"
                 summary += f"   Published: {dataset.get('datePublished', 'Unknown')}\n"
                 summary += f"   viewUrl: {version.get('viewUrl', 'Unknown')}\n"
+                if version.get("url"):
+                    summary += f"   url: {version.get('url')}\n"
+                if version.get("previous"):
+                    summary += f"   previous: {version.get('previous')}\n"
+                if version.get("next"):
+                    summary += f"   next: {version.get('next')}\n"
                 if i < len(versions):
                     summary += "\n"
 
@@ -1588,6 +1680,10 @@ class ESSDiveClient:
                 detailed += f"   isPublic: {version.get('isPublic', 'Unknown')}\n"
                 detailed += f"   viewUrl: {version.get('viewUrl', 'Unknown')}\n"
                 detailed += f"   url: {version.get('url', 'Unknown')}\n"
+                if version.get("previous"):
+                    detailed += f"   previous: {version.get('previous')}\n"
+                if version.get("next"):
+                    detailed += f"   next: {version.get('next')}\n"
 
                 description = dataset.get("description", "")
                 if isinstance(description, list):

--- a/src/essdive_mcp/main.py
+++ b/src/essdive_mcp/main.py
@@ -74,6 +74,7 @@ from urllib.parse import quote
 from urllib.parse import quote as url_quote
 
 from fastmcp import FastMCP
+from fastmcp.server.context import Context
 
 
 LOGGER = logging.getLogger("essdive_mcp")
@@ -470,15 +471,16 @@ class VersionsPaginationState:
 
 
 class PaginationStateStore:
-    """Track the most recent dataset-search and version-history context."""
+    """Track per-session dataset-search and version-history context."""
 
     def __init__(self) -> None:
-        self.search: Optional[SearchPaginationState] = None
-        self.versions: Optional[VersionsPaginationState] = None
+        self.search_by_session: Dict[str, SearchPaginationState] = {}
+        self.versions_by_session: Dict[str, VersionsPaginationState] = {}
 
     def save_search(
         self,
         *,
+        session_id: str,
         search_kwargs: Dict[str, Any],
         local_filters: Dict[str, List[str]],
         format_type: str,
@@ -488,7 +490,7 @@ class PaginationStateStore:
         base_kwargs["cursor"] = None
         base_kwargs["row_start"] = None
 
-        self.search = SearchPaginationState(
+        self.search_by_session[session_id] = SearchPaginationState(
             search_kwargs=base_kwargs,
             local_filters={key: list(values) for key, values in local_filters.items()},
             format_type=format_type,
@@ -498,41 +500,44 @@ class PaginationStateStore:
 
     def get_search_followup(
         self,
+        session_id: str,
         direction: str,
         *,
         format_override: Optional[str] = None,
     ) -> tuple[Dict[str, Any], Dict[str, List[str]], str]:
-        if not self.search:
+        search_state = self.search_by_session.get(session_id)
+        if not search_state:
             raise ValueError("No prior dataset search is available for pagination.")
 
         cursor = (
-            self.search.next_cursor
+            search_state.next_cursor
             if direction == "next"
-            else self.search.previous_cursor
+            else search_state.previous_cursor
         )
         if not cursor:
             raise ValueError(
                 f"No {direction} page is available for the most recent dataset search."
             )
 
-        followup_kwargs = dict(self.search.search_kwargs)
+        followup_kwargs = dict(search_state.search_kwargs)
         followup_kwargs["cursor"] = cursor
         followup_kwargs["row_start"] = None
         followup_kwargs["page_size"] = None
         return (
             followup_kwargs,
-            {key: list(values) for key, values in self.search.local_filters.items()},
-            format_override or self.search.format_type,
+            {key: list(values) for key, values in search_state.local_filters.items()},
+            format_override or search_state.format_type,
         )
 
     def save_versions(
         self,
         *,
+        session_id: str,
         identifier: str,
         format_type: str,
         result: Dict[str, Any],
     ) -> None:
-        self.versions = VersionsPaginationState(
+        self.versions_by_session[session_id] = VersionsPaginationState(
             identifier=identifier,
             format_type=format_type,
             next_cursor=result.get("nextCursor"),
@@ -541,19 +546,21 @@ class PaginationStateStore:
 
     def get_versions_followup(
         self,
+        session_id: str,
         direction: str,
         *,
         format_override: Optional[str] = None,
     ) -> tuple[str, str, str]:
-        if not self.versions:
+        versions_state = self.versions_by_session.get(session_id)
+        if not versions_state:
             raise ValueError(
                 "No prior dataset-version request is available for pagination."
             )
 
         cursor = (
-            self.versions.next_cursor
+            versions_state.next_cursor
             if direction == "next"
-            else self.versions.previous_cursor
+            else versions_state.previous_cursor
         )
         if not cursor:
             raise ValueError(
@@ -561,9 +568,9 @@ class PaginationStateStore:
             )
 
         return (
-            self.versions.identifier,
+            versions_state.identifier,
             cursor,
-            format_override or self.versions.format_type,
+            format_override or versions_state.format_type,
         )
 
 
@@ -2263,6 +2270,7 @@ def main():
         row_start: Optional[int] = None,
         page_size: Optional[int] = None,
         format: str = "summary",
+        ctx: Context = None,
     ) -> str:
         """
         Search for datasets in the ESS-DIVE repository.
@@ -2388,6 +2396,7 @@ def main():
                 local_filters=local_filters,
             )
             pagination_store.save_search(
+                session_id=ctx.session_id,
                 search_kwargs=search_kwargs,
                 local_filters=local_filters,
                 format_type=format,
@@ -2438,7 +2447,7 @@ def main():
         name="next-search-page",
         description="Show the next page of the most recent dataset search",
     )
-    async def next_search_page(format: Optional[str] = None) -> str:
+    async def next_search_page(format: Optional[str] = None, ctx: Context = None) -> str:
         """
         Show the next page of the most recent dataset search.
 
@@ -2454,7 +2463,9 @@ def main():
         LOGGER.debug("Tool next-search-page called format=%s", format)
         try:
             search_kwargs, local_filters, format_type = (
-                pagination_store.get_search_followup("next", format_override=format)
+                pagination_store.get_search_followup(
+                    ctx.session_id, "next", format_override=format
+                )
             )
             result = await _execute_dataset_search_request(
                 client,
@@ -2462,6 +2473,7 @@ def main():
                 local_filters=local_filters,
             )
             pagination_store.save_search(
+                session_id=ctx.session_id,
                 search_kwargs=search_kwargs,
                 local_filters=local_filters,
                 format_type=format_type,
@@ -2481,7 +2493,7 @@ def main():
         name="previous-search-page",
         description="Show the previous page of the most recent dataset search",
     )
-    async def previous_search_page(format: Optional[str] = None) -> str:
+    async def previous_search_page(format: Optional[str] = None, ctx: Context = None) -> str:
         """
         Show the previous page of the most recent dataset search.
 
@@ -2498,7 +2510,7 @@ def main():
         try:
             search_kwargs, local_filters, format_type = (
                 pagination_store.get_search_followup(
-                    "previous", format_override=format)
+                    ctx.session_id, "previous", format_override=format)
             )
             result = await _execute_dataset_search_request(
                 client,
@@ -2506,6 +2518,7 @@ def main():
                 local_filters=local_filters,
             )
             pagination_store.save_search(
+                session_id=ctx.session_id,
                 search_kwargs=search_kwargs,
                 local_filters=local_filters,
                 format_type=format_type,
@@ -2600,6 +2613,7 @@ def main():
         page_size: Optional[int] = None,
         cursor: Optional[str] = None,
         format: str = "summary",
+        ctx: Context = None,
     ) -> str:
         """
         List visible versions for a dataset from newest to oldest.
@@ -2632,6 +2646,7 @@ def main():
                 cursor=cursor,
             )
             pagination_store.save_versions(
+                session_id=ctx.session_id,
                 identifier=id,
                 format_type=format,
                 result=result,
@@ -2658,7 +2673,7 @@ def main():
         name="next-dataset-versions-page",
         description="Show the next page of the most recent dataset-version history request",
     )
-    async def next_dataset_versions_page(format: Optional[str] = None) -> str:
+    async def next_dataset_versions_page(format: Optional[str] = None, ctx: Context = None) -> str:
         """
         Show the next page of the most recent dataset-version history request.
 
@@ -2676,13 +2691,14 @@ def main():
         try:
             identifier, cursor_value, format_type = (
                 pagination_store.get_versions_followup(
-                    "next", format_override=format)
+                    ctx.session_id, "next", format_override=format)
             )
             result = await client.get_dataset_versions(
                 identifier,
                 cursor=cursor_value,
             )
             pagination_store.save_versions(
+                session_id=ctx.session_id,
                 identifier=identifier,
                 format_type=format_type,
                 result=result,
@@ -2701,7 +2717,7 @@ def main():
         name="previous-dataset-versions-page",
         description="Show the previous page of the most recent dataset-version history request",
     )
-    async def previous_dataset_versions_page(format: Optional[str] = None) -> str:
+    async def previous_dataset_versions_page(format: Optional[str] = None, ctx: Context = None) -> str:
         """
         Show the previous page of the most recent dataset-version history request.
 
@@ -2719,13 +2735,14 @@ def main():
         try:
             identifier, cursor_value, format_type = (
                 pagination_store.get_versions_followup(
-                    "previous", format_override=format)
+                    ctx.session_id, "previous", format_override=format)
             )
             result = await client.get_dataset_versions(
                 identifier,
                 cursor=cursor_value,
             )
             pagination_store.save_versions(
+                session_id=ctx.session_id,
                 identifier=identifier,
                 format_type=format_type,
                 result=result,

--- a/src/essdive_mcp/main.py
+++ b/src/essdive_mcp/main.py
@@ -413,6 +413,36 @@ def _summarize_provider(provider: Any) -> List[str]:
     return summaries
 
 
+def _format_result_user_note(user: Any) -> Optional[str]:
+    """Return a human-readable visibility note derived from the API user field."""
+    if user is None:
+        return None
+
+    user_text = str(user).strip()
+    if not user_text:
+        return None
+    if user_text == "anonymous":
+        return "Results include public data only."
+    return f"User: {user_text}"
+
+
+def _should_show_is_public(value: Any, user: Any) -> bool:
+    """Hide redundant public flags for anonymous result sets."""
+    if value is None:
+        return False
+    user_text = str(user).strip() if user is not None else ""
+    if user_text == "anonymous" and value is True:
+        return False
+    return True
+
+
+def _markdown_link(label: str, url: Optional[str]) -> Optional[str]:
+    """Return a Markdown link when a URL is available."""
+    if not url:
+        return None
+    return f"[{label}]({url})"
+
+
 def _distribution_search_strings(
     distribution: Any,
     *,
@@ -1279,8 +1309,7 @@ class ESSDiveClient:
         query = results.get("query", {}) if isinstance(
             results.get("query"), dict) else {}
         sort_value = query.get("sort")
-        has_cursor_pagination = "nextCursor" in results or "previousCursor" in results
-        user = results.get("user")
+        user_note = _format_result_user_note(results.get("user"))
 
         if filtering:
             native_total = filtering.get("native_total")
@@ -1297,13 +1326,8 @@ class ESSDiveClient:
 
         if sort_value:
             header += f"Sort: {sort_value}\n\n"
-        if user:
-            header += f"User: {user}\n\n"
-        if has_cursor_pagination:
-            header += (
-                f"Pagination: previousCursor={results.get('previousCursor') or 'None'}; "
-                f"nextCursor={results.get('nextCursor') or 'None'}\n\n"
-            )
+        if user_note:
+            header += f"{user_note}\n\n"
 
         if format_type == "summary":
             summary = header
@@ -1312,16 +1336,18 @@ class ESSDiveClient:
                 ds_data = dataset.get("dataset", {})
                 summary += f"{i}. {ds_data.get('name', 'Untitled')}\n"
                 summary += f"   ID: {dataset.get('id', 'Unknown')}\n"
-                if "isPublic" in dataset:
+                if _should_show_is_public(dataset.get("isPublic"), results.get("user")):
                     summary += f"   isPublic: {dataset.get('isPublic')}\n"
                 summary += f"   Published: {ds_data.get('datePublished', 'Unknown')}\n"
-                summary += f"   viewUrl: {dataset.get('viewUrl', 'Unknown')}\n"
-                if dataset.get("url"):
-                    summary += f"   url: {dataset.get('url')}\n"
-                if dataset.get("previous"):
-                    summary += f"   previous: {dataset.get('previous')}\n"
-                if dataset.get("next"):
-                    summary += f"   next: {dataset.get('next')}\n"
+                links = [
+                    _markdown_link("View dataset", dataset.get("viewUrl")),
+                    _markdown_link("API record", dataset.get("url")),
+                    _markdown_link("Previous version", dataset.get("previous")),
+                    _markdown_link("Next version", dataset.get("next")),
+                ]
+                links = [link for link in links if link]
+                if links:
+                    summary += f"   Links: {' | '.join(links)}\n"
                 if i < len(datasets):
                     summary += "\n"
 
@@ -1334,20 +1360,22 @@ class ESSDiveClient:
                 ds_data = dataset.get("dataset", {})
                 detailed += f"{i}. {ds_data.get('name', 'Untitled')}\n"
                 detailed += f"   ID: {dataset.get('id', 'Unknown')}\n"
-                if "isPublic" in dataset:
+                if _should_show_is_public(dataset.get("isPublic"), results.get("user")):
                     detailed += f"   isPublic: {dataset.get('isPublic')}\n"
                 if dataset.get("dateUploaded"):
                     detailed += f"   dateUploaded: {dataset.get('dateUploaded')}\n"
                 if dataset.get("dateModified"):
                     detailed += f"   dateModified: {dataset.get('dateModified')}\n"
                 detailed += f"   Published: {ds_data.get('datePublished', 'Unknown')}\n"
-                detailed += f"   viewUrl: {dataset.get('viewUrl', 'Unknown')}\n"
-                if dataset.get("url"):
-                    detailed += f"   url: {dataset.get('url')}\n"
-                if dataset.get("previous"):
-                    detailed += f"   previous: {dataset.get('previous')}\n"
-                if dataset.get("next"):
-                    detailed += f"   next: {dataset.get('next')}\n"
+                links = [
+                    _markdown_link("View dataset", dataset.get("viewUrl")),
+                    _markdown_link("API record", dataset.get("url")),
+                    _markdown_link("Previous version", dataset.get("previous")),
+                    _markdown_link("Next version", dataset.get("next")),
+                ]
+                links = [link for link in links if link]
+                if links:
+                    detailed += f"   Links: {' | '.join(links)}\n"
 
                 # Add description if available
                 description = ds_data.get("description", "")
@@ -1455,14 +1483,15 @@ class ESSDiveClient:
         content += f"**id**: {result.get('id', 'Unknown')}\n"
         if doi:
             content += f"**doi**: {doi}\n"
-        if result.get("viewUrl"):
-            content += f"**viewUrl**: {result.get('viewUrl')}\n"
-        if result.get("url"):
-            content += f"**url**: {result.get('url')}\n"
-        if result.get("previous"):
-            content += f"**previous**: {result.get('previous')}\n"
-        if result.get("next"):
-            content += f"**next**: {result.get('next')}\n"
+        links = [
+            _markdown_link("View dataset", result.get("viewUrl")),
+            _markdown_link("API record", result.get("url")),
+            _markdown_link("Previous version", result.get("previous")),
+            _markdown_link("Next version", result.get("next")),
+        ]
+        links = [link for link in links if link]
+        if links:
+            content += f"**links**: {' | '.join(links)}\n"
         if result.get("dateUploaded"):
             content += f"**dateUploaded**: {result.get('dateUploaded')}\n"
         if result.get("dateModified"):
@@ -1624,22 +1653,16 @@ class ESSDiveClient:
 
         versions = results["result"]
         total = results.get("total", 0)
-        user = results.get("user")
+        user_note = _format_result_user_note(results.get("user"))
         header = (
             f"Found {total} visible dataset versions. "
             f"Showing {len(versions)} results from newest to oldest:\n"
         )
-
-        pagination = (
-            "\nPagination:\n"
-            f"  previousCursor: {results.get('previousCursor') or 'None'}\n"
-            f"  nextCursor: {results.get('nextCursor') or 'None'}\n\n"
-        )
-        if user:
-            header += f"User: {user}\n"
+        if user_note:
+            header += f"{user_note}\n"
 
         if format_type == "summary":
-            summary = header + pagination
+            summary = f"{header}\n"
 
             for i, version in enumerate(versions, 1):
                 dataset = version.get("dataset", {})
@@ -1648,24 +1671,26 @@ class ESSDiveClient:
                 summary += f"   ID: {version.get('id', 'Unknown')}\n"
                 if doi:
                     summary += f"   DOI: {doi}\n"
-                if "isPublic" in version:
+                if _should_show_is_public(version.get("isPublic"), results.get("user")):
                     summary += f"   isPublic: {version.get('isPublic')}\n"
                 summary += f"   dateUploaded: {version.get('dateUploaded', 'Unknown')}\n"
                 summary += f"   Published: {dataset.get('datePublished', 'Unknown')}\n"
-                summary += f"   viewUrl: {version.get('viewUrl', 'Unknown')}\n"
-                if version.get("url"):
-                    summary += f"   url: {version.get('url')}\n"
-                if version.get("previous"):
-                    summary += f"   previous: {version.get('previous')}\n"
-                if version.get("next"):
-                    summary += f"   next: {version.get('next')}\n"
+                links = [
+                    _markdown_link("View dataset", version.get("viewUrl")),
+                    _markdown_link("API record", version.get("url")),
+                    _markdown_link("Previous version", version.get("previous")),
+                    _markdown_link("Next version", version.get("next")),
+                ]
+                links = [link for link in links if link]
+                if links:
+                    summary += f"   Links: {' | '.join(links)}\n"
                 if i < len(versions):
                     summary += "\n"
 
             return summary
 
         if format_type == "detailed":
-            detailed = header + pagination
+            detailed = f"{header}\n"
 
             for i, version in enumerate(versions, 1):
                 dataset = version.get("dataset", {})
@@ -1677,13 +1702,17 @@ class ESSDiveClient:
                 detailed += f"   dateUploaded: {version.get('dateUploaded', 'Unknown')}\n"
                 detailed += f"   dateModified: {version.get('dateModified', 'Unknown')}\n"
                 detailed += f"   Published: {dataset.get('datePublished', 'Unknown')}\n"
-                detailed += f"   isPublic: {version.get('isPublic', 'Unknown')}\n"
-                detailed += f"   viewUrl: {version.get('viewUrl', 'Unknown')}\n"
-                detailed += f"   url: {version.get('url', 'Unknown')}\n"
-                if version.get("previous"):
-                    detailed += f"   previous: {version.get('previous')}\n"
-                if version.get("next"):
-                    detailed += f"   next: {version.get('next')}\n"
+                if _should_show_is_public(version.get("isPublic"), results.get("user")):
+                    detailed += f"   isPublic: {version.get('isPublic', 'Unknown')}\n"
+                links = [
+                    _markdown_link("View dataset", version.get("viewUrl")),
+                    _markdown_link("API record", version.get("url")),
+                    _markdown_link("Previous version", version.get("previous")),
+                    _markdown_link("Next version", version.get("next")),
+                ]
+                links = [link for link in links if link]
+                if links:
+                    detailed += f"   Links: {' | '.join(links)}\n"
 
                 description = dataset.get("description", "")
                 if isinstance(description, list):

--- a/src/essdive_mcp/main.py
+++ b/src/essdive_mcp/main.py
@@ -62,12 +62,15 @@ import csv
 import re
 import logging
 import traceback
+from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
+from threading import RLock
+from time import monotonic
 import requests
 from io import StringIO
-from typing import Dict, List, Optional, Any, Union, Awaitable, TypeVar
+from typing import Dict, List, Optional, Any, Union, Awaitable, Callable, TypeVar
 import httpx
 import yaml
 from urllib.parse import quote
@@ -79,6 +82,8 @@ from fastmcp.server.context import Context
 
 LOGGER = logging.getLogger("essdive_mcp")
 REQUEST_TIMEOUT_SECONDS = 30.0
+PAGINATION_STATE_TTL_SECONDS = 1800.0
+PAGINATION_STATE_CLEANUP_INTERVAL_SECONDS = 60.0
 T = TypeVar("T")
 PROJECT_PORTALS_PATH = (
     Path(__file__).resolve().parents[2]
@@ -458,6 +463,7 @@ class SearchPaginationState:
     format_type: str
     next_cursor: Optional[str]
     previous_cursor: Optional[str]
+    last_touched_monotonic: float
 
 
 @dataclass
@@ -468,19 +474,79 @@ class VersionsPaginationState:
     format_type: str
     next_cursor: Optional[str]
     previous_cursor: Optional[str]
+    last_touched_monotonic: float
 
 
 class PaginationStateStore:
-    """Track per-session dataset-search and version-history context."""
+    """Track per-session pagination chains with idle expiry."""
 
-    def __init__(self) -> None:
-        self.search_by_session: Dict[str, SearchPaginationState] = {}
-        self.versions_by_session: Dict[str, VersionsPaginationState] = {}
+    def __init__(
+        self,
+        *,
+        ttl_seconds: float = PAGINATION_STATE_TTL_SECONDS,
+        time_fn: Callable[[], float] = monotonic,
+    ) -> None:
+        self.search_by_session: Dict[str, Dict[str, SearchPaginationState]] = {}
+        self.active_search_by_session: Dict[str, str] = {}
+        self.versions_by_session: Dict[str, Dict[str, VersionsPaginationState]] = {}
+        self.active_versions_by_session: Dict[str, str] = {}
+        self._ttl_seconds = ttl_seconds
+        self._time_fn = time_fn
+        self._lock = RLock()
+
+    def clear_session(self, session_id: str) -> None:
+        """Remove all stored pagination state for a single session."""
+        with self._lock:
+            self.search_by_session.pop(session_id, None)
+            self.active_search_by_session.pop(session_id, None)
+            self.versions_by_session.pop(session_id, None)
+            self.active_versions_by_session.pop(session_id, None)
+
+    def clear_all(self) -> None:
+        """Remove all stored pagination state."""
+        with self._lock:
+            self.search_by_session.clear()
+            self.active_search_by_session.clear()
+            self.versions_by_session.clear()
+            self.active_versions_by_session.clear()
+
+    def prune_expired(self) -> int:
+        """Remove idle pagination state and return the number of entries deleted."""
+        with self._lock:
+            return self._prune_expired_locked(self._time_fn())
+
+    def _prune_expired_locked(self, now: float) -> int:
+        expired_count = 0
+
+        for session_id, states in list(self.search_by_session.items()):
+            for state_id, state in list(states.items()):
+                if now - state.last_touched_monotonic >= self._ttl_seconds:
+                    del states[state_id]
+                    expired_count += 1
+            active_state_id = self.active_search_by_session.get(session_id)
+            if active_state_id and active_state_id not in states:
+                self.active_search_by_session.pop(session_id, None)
+            if not states:
+                self.search_by_session.pop(session_id, None)
+
+        for session_id, states in list(self.versions_by_session.items()):
+            for state_id, state in list(states.items()):
+                if now - state.last_touched_monotonic >= self._ttl_seconds:
+                    del states[state_id]
+                    expired_count += 1
+            active_state_id = self.active_versions_by_session.get(session_id)
+            if active_state_id and active_state_id not in states:
+                self.active_versions_by_session.pop(session_id, None)
+            if not states:
+                self.versions_by_session.pop(session_id, None)
+
+        return expired_count
 
     def save_search(
         self,
         *,
         session_id: str,
+        state_id: str,
         search_kwargs: Dict[str, Any],
         local_filters: Dict[str, List[str]],
         format_type: str,
@@ -490,13 +556,19 @@ class PaginationStateStore:
         base_kwargs["cursor"] = None
         base_kwargs["row_start"] = None
 
-        self.search_by_session[session_id] = SearchPaginationState(
-            search_kwargs=base_kwargs,
-            local_filters={key: list(values) for key, values in local_filters.items()},
-            format_type=format_type,
-            next_cursor=result.get("nextCursor"),
-            previous_cursor=result.get("previousCursor"),
-        )
+        now = self._time_fn()
+        with self._lock:
+            self._prune_expired_locked(now)
+            session_states = self.search_by_session.setdefault(session_id, {})
+            session_states[state_id] = SearchPaginationState(
+                search_kwargs=base_kwargs,
+                local_filters={key: list(values) for key, values in local_filters.items()},
+                format_type=format_type,
+                next_cursor=result.get("nextCursor"),
+                previous_cursor=result.get("previousCursor"),
+                last_touched_monotonic=now,
+            )
+            self.active_search_by_session[session_id] = state_id
 
     def get_search_followup(
         self,
@@ -504,45 +576,64 @@ class PaginationStateStore:
         direction: str,
         *,
         format_override: Optional[str] = None,
-    ) -> tuple[Dict[str, Any], Dict[str, List[str]], str]:
-        search_state = self.search_by_session.get(session_id)
-        if not search_state:
-            raise ValueError("No prior dataset search is available for pagination.")
-
-        cursor = (
-            search_state.next_cursor
-            if direction == "next"
-            else search_state.previous_cursor
-        )
-        if not cursor:
-            raise ValueError(
-                f"No {direction} page is available for the most recent dataset search."
+    ) -> tuple[str, Dict[str, Any], Dict[str, List[str]], str]:
+        now = self._time_fn()
+        with self._lock:
+            self._prune_expired_locked(now)
+            active_state_id = self.active_search_by_session.get(session_id)
+            session_states = self.search_by_session.get(session_id) or {}
+            search_state = (
+                session_states.get(active_state_id) if active_state_id else None
             )
+            if not search_state:
+                raise ValueError("No prior dataset search is available for pagination.")
 
-        followup_kwargs = dict(search_state.search_kwargs)
-        followup_kwargs["cursor"] = cursor
-        followup_kwargs["row_start"] = None
-        followup_kwargs["page_size"] = None
-        return (
-            followup_kwargs,
-            {key: list(values) for key, values in search_state.local_filters.items()},
-            format_override or search_state.format_type,
-        )
+            cursor = (
+                search_state.next_cursor
+                if direction == "next"
+                else search_state.previous_cursor
+            )
+            if not cursor:
+                raise ValueError(
+                    f"No {direction} page is available for the most recent dataset search."
+                )
+
+            search_state.last_touched_monotonic = now
+            followup_kwargs = dict(search_state.search_kwargs)
+            followup_kwargs["cursor"] = cursor
+            followup_kwargs["row_start"] = None
+            followup_kwargs["page_size"] = None
+            return (
+                active_state_id,
+                followup_kwargs,
+                {
+                    key: list(values)
+                    for key, values in search_state.local_filters.items()
+                },
+                format_override or search_state.format_type,
+            )
 
     def save_versions(
         self,
         *,
         session_id: str,
+        state_id: str,
         identifier: str,
         format_type: str,
         result: Dict[str, Any],
     ) -> None:
-        self.versions_by_session[session_id] = VersionsPaginationState(
-            identifier=identifier,
-            format_type=format_type,
-            next_cursor=result.get("nextCursor"),
-            previous_cursor=result.get("previousCursor"),
-        )
+        now = self._time_fn()
+        with self._lock:
+            self._prune_expired_locked(now)
+            session_states = self.versions_by_session.setdefault(session_id, {})
+            session_states[state_id] = VersionsPaginationState(
+                identifier=identifier,
+                format_type=format_type,
+                next_cursor=result.get("nextCursor"),
+                previous_cursor=result.get("previousCursor"),
+                last_touched_monotonic=now,
+            )
+            self.active_versions_by_session[session_id] = state_id
 
     def get_versions_followup(
         self,
@@ -550,28 +641,50 @@ class PaginationStateStore:
         direction: str,
         *,
         format_override: Optional[str] = None,
-    ) -> tuple[str, str, str]:
-        versions_state = self.versions_by_session.get(session_id)
-        if not versions_state:
-            raise ValueError(
-                "No prior dataset-version request is available for pagination."
+    ) -> tuple[str, str, str, str]:
+        now = self._time_fn()
+        with self._lock:
+            self._prune_expired_locked(now)
+            active_state_id = self.active_versions_by_session.get(session_id)
+            session_states = self.versions_by_session.get(session_id) or {}
+            versions_state = (
+                session_states.get(active_state_id) if active_state_id else None
+            )
+            if not versions_state:
+                raise ValueError(
+                    "No prior dataset-version request is available for pagination."
+                )
+
+            cursor = (
+                versions_state.next_cursor
+                if direction == "next"
+                else versions_state.previous_cursor
+            )
+            if not cursor:
+                raise ValueError(
+                    f"No {direction} page is available for the most recent dataset-version request."
+                )
+
+            versions_state.last_touched_monotonic = now
+            return (
+                active_state_id,
+                versions_state.identifier,
+                cursor,
+                format_override or versions_state.format_type,
             )
 
-        cursor = (
-            versions_state.next_cursor
-            if direction == "next"
-            else versions_state.previous_cursor
-        )
-        if not cursor:
-            raise ValueError(
-                f"No {direction} page is available for the most recent dataset-version request."
-            )
 
-        return (
-            versions_state.identifier,
-            cursor,
-            format_override or versions_state.format_type,
-        )
+async def _run_pagination_state_cleanup(
+    pagination_store: PaginationStateStore,
+    *,
+    interval_seconds: float = PAGINATION_STATE_CLEANUP_INTERVAL_SECONDS,
+) -> None:
+    """Periodically evict idle pagination state while the server is running."""
+    while True:
+        await asyncio.sleep(interval_seconds)
+        expired_entries = pagination_store.prune_expired()
+        if expired_entries:
+            LOGGER.debug("Expired %s idle pagination-state entries", expired_entries)
 
 
 async def _execute_dataset_search_request(
@@ -2234,12 +2347,25 @@ def main():
         bool(api_token),
     )
 
-    # Create a FastMCP server
-    server = FastMCP("essdive_mcp")
-
     # Create a client for the ESS-DIVE API with the provided token
     client = ESSDiveClient(api_token=api_token)
     pagination_store = PaginationStateStore()
+
+    @asynccontextmanager
+    async def server_lifespan(_: FastMCP):
+        cleanup_task = asyncio.create_task(
+            _run_pagination_state_cleanup(pagination_store)
+        )
+        try:
+            yield {}
+        finally:
+            cleanup_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await cleanup_task
+            pagination_store.clear_all()
+
+    # Create a FastMCP server
+    server = FastMCP("essdive_mcp", lifespan=server_lifespan)
 
     # Register tool functions
     @server.tool(name="search-datasets", description="Search for datasets in ESS-DIVE")
@@ -2397,6 +2523,7 @@ def main():
             )
             pagination_store.save_search(
                 session_id=ctx.session_id,
+                state_id=ctx.request_id,
                 search_kwargs=search_kwargs,
                 local_filters=local_filters,
                 format_type=format,
@@ -2462,7 +2589,7 @@ def main():
         """
         LOGGER.debug("Tool next-search-page called format=%s", format)
         try:
-            search_kwargs, local_filters, format_type = (
+            state_id, search_kwargs, local_filters, format_type = (
                 pagination_store.get_search_followup(
                     ctx.session_id, "next", format_override=format
                 )
@@ -2474,6 +2601,7 @@ def main():
             )
             pagination_store.save_search(
                 session_id=ctx.session_id,
+                state_id=state_id,
                 search_kwargs=search_kwargs,
                 local_filters=local_filters,
                 format_type=format_type,
@@ -2508,7 +2636,7 @@ def main():
         """
         LOGGER.debug("Tool previous-search-page called format=%s", format)
         try:
-            search_kwargs, local_filters, format_type = (
+            state_id, search_kwargs, local_filters, format_type = (
                 pagination_store.get_search_followup(
                     ctx.session_id, "previous", format_override=format)
             )
@@ -2519,6 +2647,7 @@ def main():
             )
             pagination_store.save_search(
                 session_id=ctx.session_id,
+                state_id=state_id,
                 search_kwargs=search_kwargs,
                 local_filters=local_filters,
                 format_type=format_type,
@@ -2647,6 +2776,7 @@ def main():
             )
             pagination_store.save_versions(
                 session_id=ctx.session_id,
+                state_id=ctx.request_id,
                 identifier=id,
                 format_type=format,
                 result=result,
@@ -2689,7 +2819,7 @@ def main():
         """
         LOGGER.debug("Tool next-dataset-versions-page called format=%s", format)
         try:
-            identifier, cursor_value, format_type = (
+            state_id, identifier, cursor_value, format_type = (
                 pagination_store.get_versions_followup(
                     ctx.session_id, "next", format_override=format)
             )
@@ -2699,6 +2829,7 @@ def main():
             )
             pagination_store.save_versions(
                 session_id=ctx.session_id,
+                state_id=state_id,
                 identifier=identifier,
                 format_type=format_type,
                 result=result,
@@ -2733,7 +2864,7 @@ def main():
         """
         LOGGER.debug("Tool previous-dataset-versions-page called format=%s", format)
         try:
-            identifier, cursor_value, format_type = (
+            state_id, identifier, cursor_value, format_type = (
                 pagination_store.get_versions_followup(
                     ctx.session_id, "previous", format_override=format)
             )
@@ -2743,6 +2874,7 @@ def main():
             )
             pagination_store.save_versions(
                 session_id=ctx.session_id,
+                state_id=state_id,
                 identifier=identifier,
                 format_type=format_type,
                 result=result,

--- a/src/essdive_mcp/main.py
+++ b/src/essdive_mcp/main.py
@@ -12,10 +12,13 @@ MCP Tools Available:
     provider, publication date, temporal coverage, keywords, geographic bounds/nearby
     search, and local metadata-aware post-filters for fields exposed on full dataset
     records. Supports pagination and multiple result formats.
-  - get-dataset: Retrieve detailed metadata for a specific dataset including creators,
-    keywords, description, and available data files.
+  - get-dataset: Retrieve detailed metadata for a specific dataset, including top-level
+    package fields such as isPublic, dateUploaded, dateModified, citation, and
+    available data files.
   - get-dataset-versions: List visible versions of a dataset from newest to oldest,
     with cursor-based pagination support for version history navigation.
+  - get-dataset-status: Get workflow/status metadata for a dataset from the
+    /packages/{identifier}/status endpoint.
   - get-dataset-permissions: Get sharing and access permission information for datasets.
 
 **Identifier Conversion:**
@@ -1266,6 +1269,8 @@ class ESSDiveClient:
                 ds_data = dataset.get("dataset", {})
                 summary += f"{i}. {ds_data.get('name', 'Untitled')}\n"
                 summary += f"   ID: {dataset.get('id', 'Unknown')}\n"
+                if "isPublic" in dataset:
+                    summary += f"   isPublic: {dataset.get('isPublic')}\n"
                 summary += f"   Published: {ds_data.get('datePublished', 'Unknown')}\n"
                 summary += f"   URL: {dataset.get('viewUrl', 'Unknown')}\n"
                 if i < len(datasets):
@@ -1280,6 +1285,12 @@ class ESSDiveClient:
                 ds_data = dataset.get("dataset", {})
                 detailed += f"{i}. {ds_data.get('name', 'Untitled')}\n"
                 detailed += f"   ID: {dataset.get('id', 'Unknown')}\n"
+                if "isPublic" in dataset:
+                    detailed += f"   isPublic: {dataset.get('isPublic')}\n"
+                if dataset.get("dateUploaded"):
+                    detailed += f"   dateUploaded: {dataset.get('dateUploaded')}\n"
+                if dataset.get("dateModified"):
+                    detailed += f"   dateModified: {dataset.get('dateModified')}\n"
                 detailed += f"   Published: {ds_data.get('datePublished', 'Unknown')}\n"
                 detailed += f"   URL: {dataset.get('viewUrl', 'Unknown')}\n"
 
@@ -1340,12 +1351,174 @@ class ESSDiveClient:
                 if license_value:
                     detailed += f"   License: {license_value}\n"
 
+                citation = dataset.get("citation")
+                if citation:
+                    detailed += f"   citation: {citation}\n"
+
                 if i < len(datasets):
                     detailed += "\n"
 
             return detailed
 
         return results
+
+    def format_dataset(
+        self, result: Dict[str, Any], format_type: str = "detailed"
+    ) -> Union[str, Dict[str, Any]]:
+        """
+        Format a single dataset record into a readable summary.
+
+        Args:
+            result: The API response from GET /packages/{identifier}
+            format_type: Type of formatting ('summary', 'detailed', 'raw')
+
+        Returns:
+            Formatted dataset metadata as string or dict
+        """
+        if format_type == "raw":
+            return result
+
+        dataset = result.get("dataset")
+        if not isinstance(dataset, dict):
+            return "No dataset found or invalid response format."
+
+        name = dataset.get("name", "Untitled")
+        description = dataset.get("description", "")
+        if isinstance(description, list):
+            description = " ".join(description)
+
+        doi = dataset.get("@id") or dataset.get("doi")
+        content = f"# {name}\n\n"
+        content += f"**id**: {result.get('id', 'Unknown')}\n"
+        if doi:
+            content += f"**doi**: {doi}\n"
+        if result.get("viewUrl"):
+            content += f"**viewUrl**: {result.get('viewUrl')}\n"
+        if result.get("dateUploaded"):
+            content += f"**dateUploaded**: {result.get('dateUploaded')}\n"
+        if result.get("dateModified"):
+            content += f"**dateModified**: {result.get('dateModified')}\n"
+        if "isPublic" in result:
+            content += f"**isPublic**: {result.get('isPublic')}\n"
+        if dataset.get("datePublished"):
+            content += f"**datePublished**: {dataset.get('datePublished')}\n"
+        if result.get("citation"):
+            content += f"**citation**: {result.get('citation')}\n"
+        content += "\n"
+
+        if format_type == "summary":
+            if description:
+                content += f"## Description\n{description}\n"
+            return content.rstrip()
+
+        if description:
+            content += f"## Description\n{description}\n\n"
+
+        creators = dataset.get("creator", [])
+        if not isinstance(creators, list):
+            creators = [creators]
+
+        if creators:
+            content += "## Creators\n"
+            for creator in creators:
+                given_name = creator.get("givenName", "")
+                family_name = creator.get("familyName", "")
+                creator_name = f"{given_name} {family_name}".strip()
+                affiliation = creator.get("affiliation", "")
+
+                content += f"- {creator_name}"
+                if affiliation:
+                    content += f" ({affiliation})"
+                content += "\n"
+            content += "\n"
+
+        keywords = dataset.get("keywords", [])
+        if not isinstance(keywords, list):
+            keywords = [keywords]
+
+        if keywords:
+            content += "## Keywords\n"
+            content += ", ".join(keywords)
+            content += "\n\n"
+
+        alternate_names = _as_string_list(dataset.get("alternateName"))
+        if alternate_names:
+            content += "## Alternate Names / Identifiers\n"
+            content += ", ".join(alternate_names)
+            content += "\n\n"
+
+        temporal_coverage = _summarize_temporal_coverage(
+            dataset.get("temporalCoverage")
+        )
+        if temporal_coverage:
+            content += "## Temporal Coverage\n"
+            content += f"{temporal_coverage}\n\n"
+
+        spatial_coverage = _summarize_spatial_coverage(
+            dataset.get("spatialCoverage")
+        )
+        if spatial_coverage:
+            content += "## Spatial Coverage\n"
+            for location in spatial_coverage:
+                content += f"- {location}\n"
+            content += "\n"
+
+        variables_measured = _as_string_list(dataset.get("variableMeasured"))
+        if variables_measured:
+            content += "## Variables Measured\n"
+            content += ", ".join(variables_measured)
+            content += "\n\n"
+
+        measurement_techniques = _as_string_list(
+            dataset.get("measurementTechnique")
+        )
+        if measurement_techniques:
+            content += "## Measurement Techniques\n"
+            for technique in measurement_techniques:
+                content += f"- {_truncate_text(technique, 500)}\n"
+            content += "\n"
+
+        funders = []
+        for funder in _as_list(dataset.get("funder")):
+            if isinstance(funder, dict):
+                funder_name = ", ".join(_organization_search_strings(funder))
+                if funder_name:
+                    funders.append(funder_name)
+            else:
+                funders.extend(_as_string_list(funder))
+        if funders:
+            content += "## Funders\n"
+            for funder in funders:
+                content += f"- {funder}\n"
+            content += "\n"
+
+        editor = dataset.get("editor")
+        if isinstance(editor, dict):
+            editor_details = _person_search_strings(editor)
+            if editor_details:
+                content += "## Contact\n"
+                content += f"- {', '.join(editor_details)}\n\n"
+
+        license_value = dataset.get("license")
+        if license_value:
+            content += "## License\n"
+            content += f"{license_value}\n\n"
+
+        distribution = dataset.get("distribution", [])
+        if distribution:
+            content += "## Data Files\n"
+            for file in distribution:
+                file_name = file.get("name", "Unknown")
+                file_size = file.get("contentSize", 0)
+                file_format = file.get("encodingFormat", "Unknown")
+                file_url = file.get("contentUrl", "Unknown")
+                file_id = file.get("identifier", "Unknown")
+                content += (
+                    f"- {file_name} ({file_size} KB, {file_format}) "
+                    f"URL: {file_url} ID: {file_id}\n"
+                )
+
+        return content
 
     def format_dataset_versions(
         self, results: Dict[str, Any], format_type: str = "summary"
@@ -1389,9 +1562,11 @@ class ESSDiveClient:
                 summary += f"   ID: {version.get('id', 'Unknown')}\n"
                 if doi:
                     summary += f"   DOI: {doi}\n"
-                summary += f"   Uploaded: {version.get('dateUploaded', 'Unknown')}\n"
+                if "isPublic" in version:
+                    summary += f"   isPublic: {version.get('isPublic')}\n"
+                summary += f"   dateUploaded: {version.get('dateUploaded', 'Unknown')}\n"
                 summary += f"   Published: {dataset.get('datePublished', 'Unknown')}\n"
-                summary += f"   URL: {version.get('viewUrl', 'Unknown')}\n"
+                summary += f"   viewUrl: {version.get('viewUrl', 'Unknown')}\n"
                 if i < len(versions):
                     summary += "\n"
 
@@ -1407,12 +1582,12 @@ class ESSDiveClient:
                 detailed += f"   ID: {version.get('id', 'Unknown')}\n"
                 if doi:
                     detailed += f"   DOI: {doi}\n"
-                detailed += f"   Uploaded: {version.get('dateUploaded', 'Unknown')}\n"
-                detailed += f"   Modified: {version.get('dateModified', 'Unknown')}\n"
+                detailed += f"   dateUploaded: {version.get('dateUploaded', 'Unknown')}\n"
+                detailed += f"   dateModified: {version.get('dateModified', 'Unknown')}\n"
                 detailed += f"   Published: {dataset.get('datePublished', 'Unknown')}\n"
-                detailed += f"   Public: {version.get('isPublic', 'Unknown')}\n"
-                detailed += f"   View URL: {version.get('viewUrl', 'Unknown')}\n"
-                detailed += f"   API URL: {version.get('url', 'Unknown')}\n"
+                detailed += f"   isPublic: {version.get('isPublic', 'Unknown')}\n"
+                detailed += f"   viewUrl: {version.get('viewUrl', 'Unknown')}\n"
+                detailed += f"   url: {version.get('url', 'Unknown')}\n"
 
                 description = dataset.get("description", "")
                 if isinstance(description, list):
@@ -1425,7 +1600,7 @@ class ESSDiveClient:
 
                 citation = version.get("citation")
                 if citation:
-                    detailed += f"   Citation: {citation}\n"
+                    detailed += f"   citation: {citation}\n"
 
                 if version.get("next"):
                     detailed += f"   Newer Version URL: {version['next']}\n"
@@ -1990,147 +2165,67 @@ def main():
         name="get-dataset",
         description="Get detailed information about a specific dataset",
     )
-    async def get_dataset(id: str) -> str:
+    async def get_dataset(id: str, format: str = "detailed") -> str:
         """
         Get detailed information about a specific dataset.
 
         Args:
             id: ESS-DIVE dataset identifier
+            format: Format of the results (summary, detailed, raw)
 
         Examples:
             get-dataset with id="ess-dive-9ea5fe57db73c90-20241024T093714082510"
+            get-dataset with id="doi:10.15485/2529445" and format="raw"
 
         Returns:
             Formatted dataset information
         """
-        LOGGER.debug("Tool get-dataset called id=%s", id)
+        LOGGER.debug("Tool get-dataset called id=%s format=%s", id, format)
         try:
             result = await client.get_dataset(id)
-
-            # Format the result
-            dataset = result.get("dataset", {})
-            name = dataset.get("name", "Untitled")
-            description = dataset.get("description", "")
-            if isinstance(description, list):
-                description = " ".join(description)
-
-            # Format basic metadata
-            content = f"# {name}\n\n"
-            content += f"**ID**: {result.get('id', 'Unknown')}\n"
-            content += f"**Published**: {dataset.get('datePublished', 'Unknown')}\n\n"
-            content += f"## Description\n{description}\n\n"
-
-            # Format creators
-            creators = dataset.get("creator", [])
-            if not isinstance(creators, list):
-                creators = [creators]
-
-            if creators:
-                content += "## Creators\n"
-                for creator in creators:
-                    given_name = creator.get("givenName", "")
-                    family_name = creator.get("familyName", "")
-                    creator_name = f"{given_name} {family_name}".strip()
-                    affiliation = creator.get("affiliation", "")
-
-                    content += f"- {creator_name}"
-                    if affiliation:
-                        content += f" ({affiliation})"
-                    content += "\n"
-                content += "\n"
-
-            # Format keywords
-            keywords = dataset.get("keywords", [])
-            if not isinstance(keywords, list):
-                keywords = [keywords]
-
-            if keywords:
-                content += "## Keywords\n"
-                content += ", ".join(keywords)
-                content += "\n\n"
-
-            alternate_names = _as_string_list(dataset.get("alternateName"))
-            if alternate_names:
-                content += "## Alternate Names / Identifiers\n"
-                content += ", ".join(alternate_names)
-                content += "\n\n"
-
-            temporal_coverage = _summarize_temporal_coverage(
-                dataset.get("temporalCoverage")
-            )
-            if temporal_coverage:
-                content += "## Temporal Coverage\n"
-                content += f"{temporal_coverage}\n\n"
-
-            spatial_coverage = _summarize_spatial_coverage(
-                dataset.get("spatialCoverage")
-            )
-            if spatial_coverage:
-                content += "## Spatial Coverage\n"
-                for location in spatial_coverage:
-                    content += f"- {location}\n"
-                content += "\n"
-
-            variables_measured = _as_string_list(
-                dataset.get("variableMeasured"))
-            if variables_measured:
-                content += "## Variables Measured\n"
-                content += ", ".join(variables_measured)
-                content += "\n\n"
-
-            measurement_techniques = _as_string_list(
-                dataset.get("measurementTechnique")
-            )
-            if measurement_techniques:
-                content += "## Measurement Techniques\n"
-                for technique in measurement_techniques:
-                    content += f"- {_truncate_text(technique, 500)}\n"
-                content += "\n"
-
-            funders = []
-            for funder in _as_list(dataset.get("funder")):
-                if isinstance(funder, dict):
-                    funder_name = ", ".join(
-                        _organization_search_strings(funder))
-                    if funder_name:
-                        funders.append(funder_name)
-                else:
-                    funders.extend(_as_string_list(funder))
-            if funders:
-                content += "## Funders\n"
-                for funder in funders:
-                    content += f"- {funder}\n"
-                content += "\n"
-
-            editor = dataset.get("editor")
-            if isinstance(editor, dict):
-                editor_details = _person_search_strings(editor)
-                if editor_details:
-                    content += "## Contact\n"
-                    content += f"- {', '.join(editor_details)}\n\n"
-
-            license_value = dataset.get("license")
-            if license_value:
-                content += "## License\n"
-                content += f"{license_value}\n\n"
-
-            # Format data files if available
-            distribution = dataset.get("distribution", [])
-            if distribution:
-                content += "## Data Files\n"
-                for file in distribution:
-                    file_name = file.get("name", "Unknown")
-                    file_size = file.get("contentSize", 0)
-                    file_format = file.get("encodingFormat", "Unknown")
-                    file_url = file.get("contentUrl", "Unknown")
-                    file_id = file.get("identifier", "Unknown")
-                    content += f"- {file_name} ({file_size} KB, {file_format}) URL: {file_url} ID: {file_id}\n"
-
-            return content
+            formatted = client.format_dataset(result, format)
+            if format == "raw":
+                return json.dumps(formatted, indent=2)
+            if isinstance(formatted, dict):
+                return json.dumps(formatted, indent=2)
+            return str(formatted)
 
         except Exception as exc:
             return _tool_error_response(
                 "get-dataset",
+                exc,
+                verbose=verbose_mode,
+                context=_context_without_none({"id": id, "format": format}),
+            )
+
+    @server.tool(
+        name="get-dataset-status",
+        description="Get publication/workflow status information for a specific dataset",
+    )
+    async def get_dataset_status_tool(id: str) -> str:
+        """
+        Get workflow/status information for a dataset from the status endpoint.
+
+        Use this tool when the user explicitly asks for a dataset's status rather than
+        its general metadata. For multiple datasets, call the tool once per identifier.
+        This endpoint may require an ESS-DIVE API token and appropriate dataset access.
+
+        Args:
+            id: ESS-DIVE dataset identifier
+
+        Examples:
+            get-dataset-status with id="ess-dive-f78cb03d11550da-20260309T160313214"
+
+        Returns:
+            JSON string containing the dataset status response
+        """
+        LOGGER.debug("Tool get-dataset-status called id=%s", id)
+        try:
+            result = await client.get_dataset_status(id)
+            return json.dumps(result, indent=2)
+        except Exception as exc:
+            return _tool_error_response(
+                "get-dataset-status",
                 exc,
                 verbose=verbose_mode,
                 context={"id": id},

--- a/src/essdive_mcp/main.py
+++ b/src/essdive_mcp/main.py
@@ -12,11 +12,15 @@ MCP Tools Available:
     provider, publication date, temporal coverage, keywords, geographic bounds/nearby
     search, and local metadata-aware post-filters for fields exposed on full dataset
     records. Supports pagination and multiple result formats.
+  - next-search-page / previous-search-page: Navigate the most recent dataset-search
+    result set without exposing raw pagination cursors.
   - get-dataset: Retrieve detailed metadata for a specific dataset, including top-level
     package fields such as isPublic, dateUploaded, dateModified, citation, and
     available data files.
   - get-dataset-versions: List visible versions of a dataset from newest to oldest,
     with cursor-based pagination support for version history navigation.
+  - next-dataset-versions-page / previous-dataset-versions-page: Navigate the most
+    recent dataset-version history request without exposing raw pagination cursors.
   - get-dataset-status: Get workflow/status metadata for a dataset from the
     /packages/{identifier}/status endpoint.
   - get-dataset-permissions: Get sharing and access permission information for datasets.
@@ -58,6 +62,7 @@ import csv
 import re
 import logging
 import traceback
+from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
 import requests
@@ -441,6 +446,148 @@ def _markdown_link(label: str, url: Optional[str]) -> Optional[str]:
     if not url:
         return None
     return f"[{label}]({url})"
+
+
+@dataclass
+class SearchPaginationState:
+    """State needed to continue paging through a dataset search."""
+
+    search_kwargs: Dict[str, Any]
+    local_filters: Dict[str, List[str]]
+    format_type: str
+    next_cursor: Optional[str]
+    previous_cursor: Optional[str]
+
+
+@dataclass
+class VersionsPaginationState:
+    """State needed to continue paging through dataset versions."""
+
+    identifier: str
+    format_type: str
+    next_cursor: Optional[str]
+    previous_cursor: Optional[str]
+
+
+class PaginationStateStore:
+    """Track the most recent dataset-search and version-history context."""
+
+    def __init__(self) -> None:
+        self.search: Optional[SearchPaginationState] = None
+        self.versions: Optional[VersionsPaginationState] = None
+
+    def save_search(
+        self,
+        *,
+        search_kwargs: Dict[str, Any],
+        local_filters: Dict[str, List[str]],
+        format_type: str,
+        result: Dict[str, Any],
+    ) -> None:
+        base_kwargs = dict(search_kwargs)
+        base_kwargs["cursor"] = None
+        base_kwargs["row_start"] = None
+
+        self.search = SearchPaginationState(
+            search_kwargs=base_kwargs,
+            local_filters={key: list(values) for key, values in local_filters.items()},
+            format_type=format_type,
+            next_cursor=result.get("nextCursor"),
+            previous_cursor=result.get("previousCursor"),
+        )
+
+    def get_search_followup(
+        self,
+        direction: str,
+        *,
+        format_override: Optional[str] = None,
+    ) -> tuple[Dict[str, Any], Dict[str, List[str]], str]:
+        if not self.search:
+            raise ValueError("No prior dataset search is available for pagination.")
+
+        cursor = (
+            self.search.next_cursor
+            if direction == "next"
+            else self.search.previous_cursor
+        )
+        if not cursor:
+            raise ValueError(
+                f"No {direction} page is available for the most recent dataset search."
+            )
+
+        followup_kwargs = dict(self.search.search_kwargs)
+        followup_kwargs["cursor"] = cursor
+        followup_kwargs["row_start"] = None
+        followup_kwargs["page_size"] = None
+        return (
+            followup_kwargs,
+            {key: list(values) for key, values in self.search.local_filters.items()},
+            format_override or self.search.format_type,
+        )
+
+    def save_versions(
+        self,
+        *,
+        identifier: str,
+        format_type: str,
+        result: Dict[str, Any],
+    ) -> None:
+        self.versions = VersionsPaginationState(
+            identifier=identifier,
+            format_type=format_type,
+            next_cursor=result.get("nextCursor"),
+            previous_cursor=result.get("previousCursor"),
+        )
+
+    def get_versions_followup(
+        self,
+        direction: str,
+        *,
+        format_override: Optional[str] = None,
+    ) -> tuple[str, str, str]:
+        if not self.versions:
+            raise ValueError(
+                "No prior dataset-version request is available for pagination."
+            )
+
+        cursor = (
+            self.versions.next_cursor
+            if direction == "next"
+            else self.versions.previous_cursor
+        )
+        if not cursor:
+            raise ValueError(
+                f"No {direction} page is available for the most recent dataset-version request."
+            )
+
+        return (
+            self.versions.identifier,
+            cursor,
+            format_override or self.versions.format_type,
+        )
+
+
+async def _execute_dataset_search_request(
+    client: "ESSDiveClient",
+    *,
+    search_kwargs: Dict[str, Any],
+    local_filters: Dict[str, List[str]],
+) -> Dict[str, Any]:
+    """Run an ESS-DIVE search and apply any local metadata filters."""
+    result = await client.search_datasets(**search_kwargs)
+    return await _apply_local_dataset_filters(client, result, local_filters)
+
+
+def _render_formatted_output(
+    formatted: Union[str, Dict[str, Any]],
+    format_type: str,
+) -> str:
+    """Serialize formatted MCP tool output."""
+    if format_type == "raw":
+        return json.dumps(formatted, indent=2)
+    if isinstance(formatted, dict):
+        return json.dumps(formatted, indent=2)
+    return str(formatted)
 
 
 def _distribution_search_strings(
@@ -2085,6 +2232,7 @@ def main():
 
     # Create a client for the ESS-DIVE API with the provided token
     client = ESSDiveClient(api_token=api_token)
+    pagination_store = PaginationStateStore()
 
     # Register tool functions
     @server.tool(name="search-datasets", description="Search for datasets in ESS-DIVE")
@@ -2216,39 +2364,39 @@ def main():
             # use query as the text search string.
             text = query if query else None
 
-            # Search for datasets using the API's native query parameters first.
-            result = await client.search_datasets(
-                row_start=row_start,
-                page_size=page_size,
-                cursor=cursor,
-                is_public=_default_dataset_search_is_public(client.api_token),
-                creator=creator,
-                provider_name=provider_name,
-                text=text,
-                date_published=date_published,
-                begin_date=begin_date,
-                end_date=end_date,
-                keywords=keywords_list,
-                sort=sort,
-                bbox=bbox,
-                lat=lat,
-                lon=lon,
-                radius=radius,
+            search_kwargs = {
+                "row_start": row_start,
+                "page_size": page_size,
+                "cursor": cursor,
+                "is_public": _default_dataset_search_is_public(client.api_token),
+                "creator": creator,
+                "provider_name": provider_name,
+                "text": text,
+                "date_published": date_published,
+                "begin_date": begin_date,
+                "end_date": end_date,
+                "keywords": keywords_list,
+                "sort": sort,
+                "bbox": bbox,
+                "lat": lat,
+                "lon": lon,
+                "radius": radius,
+            }
+            result = await _execute_dataset_search_request(
+                client,
+                search_kwargs=search_kwargs,
+                local_filters=local_filters,
             )
-
-            # Apply extra metadata filters locally when the API does not support
-            # them as first-class /packages query params.
-            result = await _apply_local_dataset_filters(client, result, local_filters)
+            pagination_store.save_search(
+                search_kwargs=search_kwargs,
+                local_filters=local_filters,
+                format_type=format,
+                result=result,
+            )
 
             # Format the results
             formatted = client.format_results(result, format)
-
-            if format == "raw":
-                return json.dumps(formatted, indent=2)
-            elif isinstance(formatted, dict):
-                return json.dumps(formatted, indent=2)
-            else:
-                return str(formatted)
+            return _render_formatted_output(formatted, format)
 
         except Exception as exc:
             return _tool_error_response(
@@ -2284,6 +2432,93 @@ def main():
                         "format": format,
                     }
                 ),
+            )
+
+    @server.tool(
+        name="next-search-page",
+        description="Show the next page of the most recent dataset search",
+    )
+    async def next_search_page(format: Optional[str] = None) -> str:
+        """
+        Show the next page of the most recent dataset search.
+
+        This tool reuses the last dataset-search filters and paging context stored by
+        `search-datasets`, so callers do not need to manage pagination cursors directly.
+
+        Args:
+            format: Optional override for the output format (summary, detailed, raw)
+
+        Returns:
+            Formatted next page of dataset search results
+        """
+        LOGGER.debug("Tool next-search-page called format=%s", format)
+        try:
+            search_kwargs, local_filters, format_type = (
+                pagination_store.get_search_followup("next", format_override=format)
+            )
+            result = await _execute_dataset_search_request(
+                client,
+                search_kwargs=search_kwargs,
+                local_filters=local_filters,
+            )
+            pagination_store.save_search(
+                search_kwargs=search_kwargs,
+                local_filters=local_filters,
+                format_type=format_type,
+                result=result,
+            )
+            formatted = client.format_results(result, format_type)
+            return _render_formatted_output(formatted, format_type)
+        except Exception as exc:
+            return _tool_error_response(
+                "next-search-page",
+                exc,
+                verbose=verbose_mode,
+                context=_context_without_none({"format": format}),
+            )
+
+    @server.tool(
+        name="previous-search-page",
+        description="Show the previous page of the most recent dataset search",
+    )
+    async def previous_search_page(format: Optional[str] = None) -> str:
+        """
+        Show the previous page of the most recent dataset search.
+
+        This tool reuses the last dataset-search filters and paging context stored by
+        `search-datasets`, so callers do not need to manage pagination cursors directly.
+
+        Args:
+            format: Optional override for the output format (summary, detailed, raw)
+
+        Returns:
+            Formatted previous page of dataset search results
+        """
+        LOGGER.debug("Tool previous-search-page called format=%s", format)
+        try:
+            search_kwargs, local_filters, format_type = (
+                pagination_store.get_search_followup(
+                    "previous", format_override=format)
+            )
+            result = await _execute_dataset_search_request(
+                client,
+                search_kwargs=search_kwargs,
+                local_filters=local_filters,
+            )
+            pagination_store.save_search(
+                search_kwargs=search_kwargs,
+                local_filters=local_filters,
+                format_type=format_type,
+                result=result,
+            )
+            formatted = client.format_results(result, format_type)
+            return _render_formatted_output(formatted, format_type)
+        except Exception as exc:
+            return _tool_error_response(
+                "previous-search-page",
+                exc,
+                verbose=verbose_mode,
+                context=_context_without_none({"format": format}),
             )
 
     @server.tool(
@@ -2396,13 +2631,13 @@ def main():
                 page_size=page_size,
                 cursor=cursor,
             )
+            pagination_store.save_versions(
+                identifier=id,
+                format_type=format,
+                result=result,
+            )
             formatted = client.format_dataset_versions(result, format)
-
-            if format == "raw":
-                return json.dumps(formatted, indent=2)
-            if isinstance(formatted, dict):
-                return json.dumps(formatted, indent=2)
-            return str(formatted)
+            return _render_formatted_output(formatted, format)
 
         except Exception as exc:
             return _tool_error_response(
@@ -2417,6 +2652,92 @@ def main():
                         "format": format,
                     }
                 ),
+            )
+
+    @server.tool(
+        name="next-dataset-versions-page",
+        description="Show the next page of the most recent dataset-version history request",
+    )
+    async def next_dataset_versions_page(format: Optional[str] = None) -> str:
+        """
+        Show the next page of the most recent dataset-version history request.
+
+        This tool reuses the last version-history paging context stored by
+        `get-dataset-versions`, so callers do not need to manage pagination cursors
+        directly.
+
+        Args:
+            format: Optional override for the output format (summary, detailed, raw)
+
+        Returns:
+            Formatted next page of dataset version history
+        """
+        LOGGER.debug("Tool next-dataset-versions-page called format=%s", format)
+        try:
+            identifier, cursor_value, format_type = (
+                pagination_store.get_versions_followup(
+                    "next", format_override=format)
+            )
+            result = await client.get_dataset_versions(
+                identifier,
+                cursor=cursor_value,
+            )
+            pagination_store.save_versions(
+                identifier=identifier,
+                format_type=format_type,
+                result=result,
+            )
+            formatted = client.format_dataset_versions(result, format_type)
+            return _render_formatted_output(formatted, format_type)
+        except Exception as exc:
+            return _tool_error_response(
+                "next-dataset-versions-page",
+                exc,
+                verbose=verbose_mode,
+                context=_context_without_none({"format": format}),
+            )
+
+    @server.tool(
+        name="previous-dataset-versions-page",
+        description="Show the previous page of the most recent dataset-version history request",
+    )
+    async def previous_dataset_versions_page(format: Optional[str] = None) -> str:
+        """
+        Show the previous page of the most recent dataset-version history request.
+
+        This tool reuses the last version-history paging context stored by
+        `get-dataset-versions`, so callers do not need to manage pagination cursors
+        directly.
+
+        Args:
+            format: Optional override for the output format (summary, detailed, raw)
+
+        Returns:
+            Formatted previous page of dataset version history
+        """
+        LOGGER.debug("Tool previous-dataset-versions-page called format=%s", format)
+        try:
+            identifier, cursor_value, format_type = (
+                pagination_store.get_versions_followup(
+                    "previous", format_override=format)
+            )
+            result = await client.get_dataset_versions(
+                identifier,
+                cursor=cursor_value,
+            )
+            pagination_store.save_versions(
+                identifier=identifier,
+                format_type=format_type,
+                result=result,
+            )
+            formatted = client.format_dataset_versions(result, format_type)
+            return _render_formatted_output(formatted, format_type)
+        except Exception as exc:
+            return _tool_error_response(
+                "previous-dataset-versions-page",
+                exc,
+                verbose=verbose_mode,
+                context=_context_without_none({"format": format}),
             )
 
     @server.tool(

--- a/tests/integration/test_api_integration.py
+++ b/tests/integration/test_api_integration.py
@@ -68,6 +68,7 @@ async def test_get_dataset_versions_live_without_token(
     assert response["pageSize"] == 2
     assert isinstance(response["result"], list)
     assert len(response["result"]) >= 1
+    assert all(isinstance(item.get("isPublic"), bool) for item in response["result"])
     assert all(item["dataset"]["@id"] == example["doi"]
                for item in response["result"])
     assert all(item.get("viewUrl") for item in response["result"])
@@ -121,6 +122,7 @@ async def test_search_public_datasets_live_without_token(
     assert isinstance(response, dict)
     assert response["total"] > 0
     assert isinstance(response["result"], list)
+    assert all(isinstance(item.get("isPublic"), bool) for item in response["result"])
     assert str(example["expected_id"]) in {
         item["id"] for item in response["result"]}
 
@@ -176,6 +178,7 @@ async def test_search_public_datasets_live_cursor_pagination_without_token():
     assert second_ids.isdisjoint(first_ids)
     assert second_page["query"]["sort"] == "name:asc"
     assert second_page["query"]["text"] == "BIONTE"
+    assert all(isinstance(item.get("isPublic"), bool) for item in second_page["result"])
 
 
 def test_doi_to_essdive_id_live_without_token(

--- a/tests/unit/test_api_unit.py
+++ b/tests/unit/test_api_unit.py
@@ -898,12 +898,14 @@ class TestFormatResults:
         assert isinstance(formatted, str)
         assert "Dataset 1" in formatted
         assert "ds1" in formatted
-        assert "isPublic: True" in formatted
-        assert "User: anonymous" in formatted
-        assert "viewUrl: https://example.com/ds1" in formatted
-        assert "url: https://api.example.com/packages/ds1" in formatted
-        assert "previous: https://api.example.com/packages/ds0" in formatted
-        assert "next: https://api.example.com/packages/ds2" in formatted
+        assert "isPublic: True" not in formatted
+        assert "Results include public data only." in formatted
+        assert (
+            "Links: [View dataset](https://example.com/ds1) | "
+            "[API record](https://api.example.com/packages/ds1) | "
+            "[Previous version](https://api.example.com/packages/ds0) | "
+            "[Next version](https://api.example.com/packages/ds2)"
+        ) in formatted
 
     def test_format_results_summary_with_local_filtering(self):
         """Summary format should mention local metadata filtering when used."""
@@ -950,8 +952,8 @@ class TestFormatResults:
 
         assert "Sort: name:asc" in formatted
 
-    def test_format_results_summary_includes_cursor_pagination(self):
-        """Summary format should expose next/previous cursors when present."""
+    def test_format_results_summary_omits_cursor_pagination(self):
+        """Summary format should not expose raw cursor values."""
         client = ESSDiveClient()
 
         results = {
@@ -969,7 +971,8 @@ class TestFormatResults:
 
         formatted = client.format_results(results, "summary")
 
-        assert "Pagination: previousCursor=None; nextCursor=next-cursor" in formatted
+        assert "Pagination:" not in formatted
+        assert "next-cursor" not in formatted
 
     def test_format_results_detailed_with_extra_metadata(self):
         """Detailed format should surface richer dataset metadata when present."""
@@ -1025,14 +1028,16 @@ class TestFormatResults:
         formatted = client.format_results(results, "detailed")
 
         assert "Alternate Names" in formatted
-        assert "isPublic: True" in formatted
-        assert "User: anonymous" in formatted
+        assert "isPublic: True" not in formatted
+        assert "Results include public data only." in formatted
         assert "dateUploaded: 2024-01-02T00:00:00Z" in formatted
         assert "dateModified: 2024-01-03T00:00:00Z" in formatted
-        assert "viewUrl: https://example.com/ds1" in formatted
-        assert "url: https://api.example.com/packages/ds1" in formatted
-        assert "previous: https://api.example.com/packages/ds0" in formatted
-        assert "next: https://api.example.com/packages/ds2" in formatted
+        assert (
+            "Links: [View dataset](https://example.com/ds1) | "
+            "[API record](https://api.example.com/packages/ds1) | "
+            "[Previous version](https://api.example.com/packages/ds0) | "
+            "[Next version](https://api.example.com/packages/ds2)"
+        ) in formatted
         assert "Temporal Coverage: 2020-01-01 to 2020-12-31" in formatted
         assert "Spatial Coverage: Pennsylvania (41.0, -77.5)" in formatted
         assert "Variables Measured: snow water equivalent" in formatted
@@ -1107,10 +1112,12 @@ class TestFormatResults:
 
         assert "**id**: ds1" in formatted
         assert "**doi**: doi:10.15485/example" in formatted
-        assert "**viewUrl**: https://example.com/ds1" in formatted
-        assert "**url**: https://api.example.com/packages/ds1" in formatted
-        assert "**previous**: https://api.example.com/packages/ds0" in formatted
-        assert "**next**: https://api.example.com/packages/ds2" in formatted
+        assert (
+            "**links**: [View dataset](https://example.com/ds1) | "
+            "[API record](https://api.example.com/packages/ds1) | "
+            "[Previous version](https://api.example.com/packages/ds0) | "
+            "[Next version](https://api.example.com/packages/ds2)"
+        ) in formatted
         assert "**dateUploaded**: 2024-01-02T00:00:00Z" in formatted
         assert "**dateModified**: 2024-01-03T00:00:00Z" in formatted
         assert "**isPublic**: True" in formatted
@@ -1163,14 +1170,18 @@ class TestFormatResults:
 
         assert isinstance(formatted, str)
         assert "Found 2 visible dataset versions" in formatted
-        assert "User: anonymous" in formatted
-        assert "nextCursor: next-cursor" in formatted
+        assert "Results include public data only." in formatted
+        assert "Pagination:" not in formatted
+        assert "next-cursor" not in formatted
         assert "ds-v2" in formatted
-        assert "isPublic: True" in formatted
+        assert "isPublic: True" not in formatted
         assert "dateUploaded: 2026-01-01T00:00:00Z" in formatted
-        assert "url: https://api.example.com/packages/ds-v2" in formatted
-        assert "previous: https://api.example.com/packages/ds-v1" in formatted
-        assert "next: https://api.example.com/packages/ds-v3" in formatted
+        assert (
+            "Links: [View dataset](https://example.com/ds-v2) | "
+            "[API record](https://api.example.com/packages/ds-v2) | "
+            "[Previous version](https://api.example.com/packages/ds-v1) | "
+            "[Next version](https://api.example.com/packages/ds-v3)"
+        ) in formatted
 
     def test_format_dataset_versions_detailed(self):
         """Detailed version format should surface citation and neighbor links."""
@@ -1205,15 +1216,17 @@ class TestFormatResults:
 
         formatted = client.format_dataset_versions(results, "detailed")
 
-        assert "User: anonymous" in formatted
+        assert "Results include public data only." in formatted
         assert "citation: Example Citation" in formatted
-        assert "isPublic: True" in formatted
+        assert "isPublic: True" not in formatted
         assert "dateUploaded: 2026-01-01T00:00:00Z" in formatted
         assert "dateModified: 2026-01-02T00:00:00Z" in formatted
-        assert "viewUrl: https://example.com/ds-v2" in formatted
-        assert "url: https://api.example.com/packages/ds-v2" in formatted
-        assert "previous: https://api.example.com/packages/ds-v1" in formatted
-        assert "next: https://api.example.com/packages/ds-v3" in formatted
+        assert (
+            "Links: [View dataset](https://example.com/ds-v2) | "
+            "[API record](https://api.example.com/packages/ds-v2) | "
+            "[Previous version](https://api.example.com/packages/ds-v1) | "
+            "[Next version](https://api.example.com/packages/ds-v3)"
+        ) in formatted
         assert "Newer Version URL" in formatted
         assert "Older Version URL" in formatted
 

--- a/tests/unit/test_api_unit.py
+++ b/tests/unit/test_api_unit.py
@@ -21,6 +21,7 @@ from essdive_mcp.main import (
     _apply_local_dataset_filters,
     _default_dataset_search_is_public,
     _resolve_startup_api_token,
+    PaginationStateStore,
 )
 import pytest
 import os
@@ -94,6 +95,95 @@ class TestDatasetSearchVisibilityDefaults:
     def test_authenticated_search_allows_private_matches(self):
         """Authenticated search should not force the API back to public-only."""
         assert _default_dataset_search_is_public("token-123") is None
+
+
+class TestPaginationStateStore:
+    """Tests for server-side pagination state used by next/previous page tools."""
+
+    def test_search_followup_reuses_stored_filters_and_next_cursor(self):
+        """Next-search-page should reuse the most recent search context."""
+        store = PaginationStateStore()
+
+        store.save_search(
+            search_kwargs={
+                "text": "soil carbon",
+                "sort": "name:asc",
+                "page_size": 2,
+                "cursor": None,
+                "row_start": 1,
+            },
+            local_filters={"funder": ["DOE"]},
+            format_type="summary",
+            result={"nextCursor": "next-cursor-123", "previousCursor": None},
+        )
+
+        search_kwargs, local_filters, format_type = store.get_search_followup("next")
+
+        assert search_kwargs == {
+            "text": "soil carbon",
+            "sort": "name:asc",
+            "page_size": None,
+            "cursor": "next-cursor-123",
+            "row_start": None,
+        }
+        assert local_filters == {"funder": ["DOE"]}
+        assert format_type == "summary"
+
+    def test_search_followup_allows_format_override(self):
+        """Follow-up search tools may override the stored output format."""
+        store = PaginationStateStore()
+        store.save_search(
+            search_kwargs={"text": "soil carbon"},
+            local_filters={},
+            format_type="summary",
+            result={"nextCursor": "next-cursor-123", "previousCursor": None},
+        )
+
+        _, _, format_type = store.get_search_followup("next", format_override="raw")
+
+        assert format_type == "raw"
+
+    def test_search_followup_requires_existing_state(self):
+        """Paging without a prior search should raise a clear error."""
+        store = PaginationStateStore()
+
+        with pytest.raises(ValueError, match="No prior dataset search"):
+            store.get_search_followup("next")
+
+    def test_search_followup_requires_requested_direction_cursor(self):
+        """Paging should fail cleanly when no next/previous cursor exists."""
+        store = PaginationStateStore()
+        store.save_search(
+            search_kwargs={"text": "soil carbon"},
+            local_filters={},
+            format_type="summary",
+            result={"nextCursor": None, "previousCursor": None},
+        )
+
+        with pytest.raises(ValueError, match="No next page is available"):
+            store.get_search_followup("next")
+
+    def test_versions_followup_reuses_identifier_and_cursor(self):
+        """Next/previous version-page tools should reuse the last versions request."""
+        store = PaginationStateStore()
+        store.save_versions(
+            identifier="doi:10.1234/example",
+            format_type="detailed",
+            result={"nextCursor": "next-version-cursor", "previousCursor": None},
+        )
+
+        identifier, cursor, format_type = store.get_versions_followup("next")
+
+        assert identifier == "doi:10.1234/example"
+        assert cursor == "next-version-cursor"
+        assert format_type == "detailed"
+
+    def test_versions_followup_requires_existing_state(self):
+        """Paging versions without a prior request should raise a clear error."""
+        store = PaginationStateStore()
+
+        with pytest.raises(ValueError, match="No prior dataset-version request"):
+            store.get_versions_followup("next")
 
 
 class TestToolErrorPayload:
@@ -469,6 +559,76 @@ class TestESSDiveClient:
             assert "rowStart" not in params
 
     @pytest.mark.asyncio
+    async def test_search_datasets_cursor_followup_flow_uses_returned_next_cursor(self):
+        """A first page's nextCursor should work unchanged for a follow-up page request."""
+        client = ESSDiveClient(api_token="test_token")
+
+        first_response = {
+            "total": 3,
+            "pageSize": 2,
+            "nextCursor": "next-cursor-123",
+            "previousCursor": None,
+            "query": {"text": "soil carbon", "sort": "name:asc"},
+            "result": [
+                {"id": "ds1", "dataset": {"name": "Dataset 1"}},
+                {"id": "ds2", "dataset": {"name": "Dataset 2"}},
+            ],
+        }
+        second_response = {
+            "total": 3,
+            "pageSize": 2,
+            "nextCursor": None,
+            "previousCursor": "prev-cursor-123",
+            "query": {"text": "soil carbon", "sort": "name:asc"},
+            "result": [
+                {"id": "ds3", "dataset": {"name": "Dataset 3"}},
+            ],
+        }
+
+        first_response_obj = Mock()
+        first_response_obj.json.return_value = first_response
+        first_response_obj.raise_for_status = Mock()
+
+        second_response_obj = Mock()
+        second_response_obj.json.return_value = second_response
+        second_response_obj.raise_for_status = Mock()
+
+        with patch("essdive_mcp.main.httpx.AsyncClient") as mock_client_class:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get = AsyncMock(
+                side_effect=[first_response_obj, second_response_obj]
+            )
+            mock_client_instance.__aenter__.return_value = mock_client_instance
+            mock_client_instance.__aexit__.return_value = None
+            mock_client_class.return_value = mock_client_instance
+
+            first_page = await client.search_datasets(
+                text="soil carbon",
+                page_size=2,
+                sort="name:asc",
+            )
+            second_page = await client.search_datasets(
+                text="soil carbon",
+                sort="name:asc",
+                cursor=first_page["nextCursor"],
+            )
+
+            assert first_page["nextCursor"] == "next-cursor-123"
+            assert second_page["result"][0]["id"] == "ds3"
+            assert second_page["previousCursor"] == "prev-cursor-123"
+
+            first_params = mock_client_instance.get.call_args_list[0].kwargs["params"]
+            second_params = mock_client_instance.get.call_args_list[1].kwargs["params"]
+            assert first_params["pageSize"] == 2
+            assert first_params["text"] == "soil carbon"
+            assert first_params["sort"] == "name:asc"
+            assert second_params == {
+                "cursor": "next-cursor-123",
+                "text": "soil carbon",
+                "sort": "name:asc",
+            }
+
+    @pytest.mark.asyncio
     async def test_search_datasets_accepts_string_bbox(self):
         """bbox may be provided in the API's comma-delimited string format."""
         client = ESSDiveClient(api_token="test_token")
@@ -803,6 +963,66 @@ class TestESSDiveClient:
 
             params = mock_client_instance.get.call_args.kwargs["params"]
             assert params == {"cursor": "cursor-123"}
+
+    @pytest.mark.asyncio
+    async def test_get_dataset_versions_cursor_followup_flow_uses_returned_next_cursor(self):
+        """A versions response nextCursor should work unchanged for a follow-up page request."""
+        client = ESSDiveClient(api_token="test_token")
+
+        first_response = {
+            "total": 3,
+            "pageSize": 2,
+            "nextCursor": "next-version-cursor",
+            "previousCursor": None,
+            "result": [
+                {"id": "ds-v3", "dataset": {"@id": "doi:10.1234/example"}},
+                {"id": "ds-v2", "dataset": {"@id": "doi:10.1234/example"}},
+            ],
+        }
+        second_response = {
+            "total": 3,
+            "pageSize": 2,
+            "nextCursor": None,
+            "previousCursor": "prev-version-cursor",
+            "result": [
+                {"id": "ds-v1", "dataset": {"@id": "doi:10.1234/example"}},
+            ],
+        }
+
+        first_response_obj = Mock()
+        first_response_obj.json.return_value = first_response
+        first_response_obj.raise_for_status = Mock()
+
+        second_response_obj = Mock()
+        second_response_obj.json.return_value = second_response
+        second_response_obj.raise_for_status = Mock()
+
+        with patch("essdive_mcp.main.httpx.AsyncClient") as mock_client_class:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get = AsyncMock(
+                side_effect=[first_response_obj, second_response_obj]
+            )
+            mock_client_instance.__aenter__.return_value = mock_client_instance
+            mock_client_instance.__aexit__.return_value = None
+            mock_client_class.return_value = mock_client_instance
+
+            first_page = await client.get_dataset_versions(
+                "doi:10.1234/example",
+                page_size=2,
+            )
+            second_page = await client.get_dataset_versions(
+                "doi:10.1234/example",
+                cursor=first_page["nextCursor"],
+            )
+
+            assert first_page["nextCursor"] == "next-version-cursor"
+            assert second_page["result"][0]["id"] == "ds-v1"
+            assert second_page["previousCursor"] == "prev-version-cursor"
+
+            first_params = mock_client_instance.get.call_args_list[0].kwargs["params"]
+            second_params = mock_client_instance.get.call_args_list[1].kwargs["params"]
+            assert first_params == {"pageSize": 2}
+            assert second_params == {"cursor": "next-version-cursor"}
 
     @pytest.mark.asyncio
     async def test_get_dataset_status(self):

--- a/tests/unit/test_api_unit.py
+++ b/tests/unit/test_api_unit.py
@@ -106,6 +106,7 @@ class TestPaginationStateStore:
 
         store.save_search(
             session_id="session-a",
+            state_id="request-1",
             search_kwargs={
                 "text": "soil carbon",
                 "sort": "name:asc",
@@ -118,9 +119,10 @@ class TestPaginationStateStore:
             result={"nextCursor": "next-cursor-123", "previousCursor": None},
         )
 
-        search_kwargs, local_filters, format_type = store.get_search_followup(
+        state_id, search_kwargs, local_filters, format_type = store.get_search_followup(
             "session-a", "next")
 
+        assert state_id == "request-1"
         assert search_kwargs == {
             "text": "soil carbon",
             "sort": "name:asc",
@@ -136,13 +138,14 @@ class TestPaginationStateStore:
         store = PaginationStateStore()
         store.save_search(
             session_id="session-a",
+            state_id="request-1",
             search_kwargs={"text": "soil carbon"},
             local_filters={},
             format_type="summary",
             result={"nextCursor": "next-cursor-123", "previousCursor": None},
         )
 
-        _, _, format_type = store.get_search_followup(
+        _, _, _, format_type = store.get_search_followup(
             "session-a", "next", format_override="raw")
 
         assert format_type == "raw"
@@ -159,6 +162,7 @@ class TestPaginationStateStore:
         store = PaginationStateStore()
         store.save_search(
             session_id="session-a",
+            state_id="request-1",
             search_kwargs={"text": "soil carbon"},
             local_filters={},
             format_type="summary",
@@ -173,6 +177,7 @@ class TestPaginationStateStore:
         store = PaginationStateStore()
         store.save_search(
             session_id="session-a",
+            state_id="request-a",
             search_kwargs={"text": "soil carbon"},
             local_filters={},
             format_type="summary",
@@ -180,33 +185,95 @@ class TestPaginationStateStore:
         )
         store.save_search(
             session_id="session-b",
+            state_id="request-b",
             search_kwargs={"text": "wildfire"},
             local_filters={},
             format_type="detailed",
             result={"nextCursor": "next-b", "previousCursor": None},
         )
 
-        kwargs_a, _, format_a = store.get_search_followup("session-a", "next")
-        kwargs_b, _, format_b = store.get_search_followup("session-b", "next")
+        _, kwargs_a, _, format_a = store.get_search_followup("session-a", "next")
+        _, kwargs_b, _, format_b = store.get_search_followup("session-b", "next")
 
         assert kwargs_a["cursor"] == "next-a"
         assert kwargs_b["cursor"] == "next-b"
         assert format_a == "summary"
         assert format_b == "detailed"
 
+    def test_search_followup_keeps_multiple_chains_within_session(self):
+        """A newer search should become active without deleting earlier chains."""
+        store = PaginationStateStore()
+        store.save_search(
+            session_id="session-a",
+            state_id="request-1",
+            search_kwargs={"text": "soil carbon"},
+            local_filters={},
+            format_type="summary",
+            result={"nextCursor": "next-a", "previousCursor": None},
+        )
+        store.save_search(
+            session_id="session-a",
+            state_id="request-2",
+            search_kwargs={"text": "wildfire"},
+            local_filters={"funder": ["DOE"]},
+            format_type="detailed",
+            result={"nextCursor": "next-b", "previousCursor": None},
+        )
+
+        state_id, kwargs, local_filters, format_type = store.get_search_followup(
+            "session-a", "next"
+        )
+
+        assert sorted(store.search_by_session["session-a"]) == ["request-1", "request-2"]
+        assert state_id == "request-2"
+        assert kwargs["text"] == "wildfire"
+        assert kwargs["cursor"] == "next-b"
+        assert local_filters == {"funder": ["DOE"]}
+        assert format_type == "detailed"
+
+    def test_search_followup_updates_existing_chain_after_followup(self):
+        """Follow-up paging should update the active chain instead of allocating a new one."""
+        store = PaginationStateStore()
+        store.save_search(
+            session_id="session-a",
+            state_id="request-1",
+            search_kwargs={"text": "soil carbon", "page_size": 2},
+            local_filters={},
+            format_type="summary",
+            result={"nextCursor": "next-a", "previousCursor": None},
+        )
+        state_id, kwargs, local_filters, format_type = store.get_search_followup(
+            "session-a", "next"
+        )
+
+        store.save_search(
+            session_id="session-a",
+            state_id=state_id,
+            search_kwargs=kwargs,
+            local_filters=local_filters,
+            format_type=format_type,
+            result={"nextCursor": "next-b", "previousCursor": "prev-b"},
+        )
+
+        assert list(store.search_by_session["session-a"]) == ["request-1"]
+        _, kwargs_after, _, _ = store.get_search_followup("session-a", "next")
+        assert kwargs_after["cursor"] == "next-b"
+
     def test_versions_followup_reuses_identifier_and_cursor(self):
         """Next/previous version-page tools should reuse the last versions request."""
         store = PaginationStateStore()
         store.save_versions(
             session_id="session-a",
+            state_id="request-1",
             identifier="doi:10.1234/example",
             format_type="detailed",
             result={"nextCursor": "next-version-cursor", "previousCursor": None},
         )
 
-        identifier, cursor, format_type = store.get_versions_followup(
+        state_id, identifier, cursor, format_type = store.get_versions_followup(
             "session-a", "next")
 
+        assert state_id == "request-1"
         assert identifier == "doi:10.1234/example"
         assert cursor == "next-version-cursor"
         assert format_type == "detailed"
@@ -223,20 +290,22 @@ class TestPaginationStateStore:
         store = PaginationStateStore()
         store.save_versions(
             session_id="session-a",
+            state_id="request-a",
             identifier="doi:10.1234/example-a",
             format_type="summary",
             result={"nextCursor": "next-a", "previousCursor": None},
         )
         store.save_versions(
             session_id="session-b",
+            state_id="request-b",
             identifier="doi:10.1234/example-b",
             format_type="raw",
             result={"nextCursor": "next-b", "previousCursor": None},
         )
 
-        identifier_a, cursor_a, format_a = store.get_versions_followup(
+        _, identifier_a, cursor_a, format_a = store.get_versions_followup(
             "session-a", "next")
-        identifier_b, cursor_b, format_b = store.get_versions_followup(
+        _, identifier_b, cursor_b, format_b = store.get_versions_followup(
             "session-b", "next")
 
         assert identifier_a == "doi:10.1234/example-a"
@@ -245,6 +314,90 @@ class TestPaginationStateStore:
         assert identifier_b == "doi:10.1234/example-b"
         assert cursor_b == "next-b"
         assert format_b == "raw"
+
+    def test_versions_followup_keeps_multiple_chains_within_session(self):
+        """Multiple version-history chains should coexist within one session."""
+        store = PaginationStateStore()
+        store.save_versions(
+            session_id="session-a",
+            state_id="request-1",
+            identifier="doi:10.1234/example-a",
+            format_type="summary",
+            result={"nextCursor": "next-a", "previousCursor": None},
+        )
+        store.save_versions(
+            session_id="session-a",
+            state_id="request-2",
+            identifier="doi:10.1234/example-b",
+            format_type="raw",
+            result={"nextCursor": "next-b", "previousCursor": None},
+        )
+
+        state_id, identifier, cursor, format_type = store.get_versions_followup(
+            "session-a", "next"
+        )
+
+        assert sorted(store.versions_by_session["session-a"]) == ["request-1", "request-2"]
+        assert state_id == "request-2"
+        assert identifier == "doi:10.1234/example-b"
+        assert cursor == "next-b"
+        assert format_type == "raw"
+
+    def test_expired_entries_are_pruned(self):
+        """Idle session state should expire after the configured timeout."""
+        current_time = 100.0
+
+        def fake_time() -> float:
+            return current_time
+
+        store = PaginationStateStore(ttl_seconds=30.0, time_fn=fake_time)
+        store.save_search(
+            session_id="session-a",
+            state_id="request-1",
+            search_kwargs={"text": "soil carbon"},
+            local_filters={},
+            format_type="summary",
+            result={"nextCursor": "next-a", "previousCursor": None},
+        )
+        store.save_versions(
+            session_id="session-a",
+            state_id="request-2",
+            identifier="doi:10.1234/example-a",
+            format_type="raw",
+            result={"nextCursor": "next-b", "previousCursor": None},
+        )
+
+        current_time = 131.0
+
+        assert store.prune_expired() == 2
+        with pytest.raises(ValueError, match="No prior dataset search"):
+            store.get_search_followup("session-a", "next")
+        with pytest.raises(ValueError, match="No prior dataset-version request"):
+            store.get_versions_followup("session-a", "next")
+
+    def test_clear_session_removes_search_and_version_state(self):
+        """Explicit session cleanup should drop all pagination data for that session."""
+        store = PaginationStateStore()
+        store.save_search(
+            session_id="session-a",
+            state_id="request-1",
+            search_kwargs={"text": "soil carbon"},
+            local_filters={},
+            format_type="summary",
+            result={"nextCursor": "next-a", "previousCursor": None},
+        )
+        store.save_versions(
+            session_id="session-a",
+            state_id="request-2",
+            identifier="doi:10.1234/example-a",
+            format_type="raw",
+            result={"nextCursor": "next-b", "previousCursor": None},
+        )
+
+        store.clear_session("session-a")
+
+        assert "session-a" not in store.search_by_session
+        assert "session-a" not in store.versions_by_session
 
 
 class TestToolErrorPayload:

--- a/tests/unit/test_api_unit.py
+++ b/tests/unit/test_api_unit.py
@@ -105,6 +105,7 @@ class TestPaginationStateStore:
         store = PaginationStateStore()
 
         store.save_search(
+            session_id="session-a",
             search_kwargs={
                 "text": "soil carbon",
                 "sort": "name:asc",
@@ -117,7 +118,8 @@ class TestPaginationStateStore:
             result={"nextCursor": "next-cursor-123", "previousCursor": None},
         )
 
-        search_kwargs, local_filters, format_type = store.get_search_followup("next")
+        search_kwargs, local_filters, format_type = store.get_search_followup(
+            "session-a", "next")
 
         assert search_kwargs == {
             "text": "soil carbon",
@@ -133,13 +135,15 @@ class TestPaginationStateStore:
         """Follow-up search tools may override the stored output format."""
         store = PaginationStateStore()
         store.save_search(
+            session_id="session-a",
             search_kwargs={"text": "soil carbon"},
             local_filters={},
             format_type="summary",
             result={"nextCursor": "next-cursor-123", "previousCursor": None},
         )
 
-        _, _, format_type = store.get_search_followup("next", format_override="raw")
+        _, _, format_type = store.get_search_followup(
+            "session-a", "next", format_override="raw")
 
         assert format_type == "raw"
 
@@ -148,12 +152,13 @@ class TestPaginationStateStore:
         store = PaginationStateStore()
 
         with pytest.raises(ValueError, match="No prior dataset search"):
-            store.get_search_followup("next")
+            store.get_search_followup("session-a", "next")
 
     def test_search_followup_requires_requested_direction_cursor(self):
         """Paging should fail cleanly when no next/previous cursor exists."""
         store = PaginationStateStore()
         store.save_search(
+            session_id="session-a",
             search_kwargs={"text": "soil carbon"},
             local_filters={},
             format_type="summary",
@@ -161,18 +166,46 @@ class TestPaginationStateStore:
         )
 
         with pytest.raises(ValueError, match="No next page is available"):
-            store.get_search_followup("next")
+            store.get_search_followup("session-a", "next")
+
+    def test_search_followup_is_scoped_per_session(self):
+        """Pagination state should not leak across sessions."""
+        store = PaginationStateStore()
+        store.save_search(
+            session_id="session-a",
+            search_kwargs={"text": "soil carbon"},
+            local_filters={},
+            format_type="summary",
+            result={"nextCursor": "next-a", "previousCursor": None},
+        )
+        store.save_search(
+            session_id="session-b",
+            search_kwargs={"text": "wildfire"},
+            local_filters={},
+            format_type="detailed",
+            result={"nextCursor": "next-b", "previousCursor": None},
+        )
+
+        kwargs_a, _, format_a = store.get_search_followup("session-a", "next")
+        kwargs_b, _, format_b = store.get_search_followup("session-b", "next")
+
+        assert kwargs_a["cursor"] == "next-a"
+        assert kwargs_b["cursor"] == "next-b"
+        assert format_a == "summary"
+        assert format_b == "detailed"
 
     def test_versions_followup_reuses_identifier_and_cursor(self):
         """Next/previous version-page tools should reuse the last versions request."""
         store = PaginationStateStore()
         store.save_versions(
+            session_id="session-a",
             identifier="doi:10.1234/example",
             format_type="detailed",
             result={"nextCursor": "next-version-cursor", "previousCursor": None},
         )
 
-        identifier, cursor, format_type = store.get_versions_followup("next")
+        identifier, cursor, format_type = store.get_versions_followup(
+            "session-a", "next")
 
         assert identifier == "doi:10.1234/example"
         assert cursor == "next-version-cursor"
@@ -183,7 +216,35 @@ class TestPaginationStateStore:
         store = PaginationStateStore()
 
         with pytest.raises(ValueError, match="No prior dataset-version request"):
-            store.get_versions_followup("next")
+            store.get_versions_followup("session-a", "next")
+
+    def test_versions_followup_is_scoped_per_session(self):
+        """Version pagination state should not leak across sessions."""
+        store = PaginationStateStore()
+        store.save_versions(
+            session_id="session-a",
+            identifier="doi:10.1234/example-a",
+            format_type="summary",
+            result={"nextCursor": "next-a", "previousCursor": None},
+        )
+        store.save_versions(
+            session_id="session-b",
+            identifier="doi:10.1234/example-b",
+            format_type="raw",
+            result={"nextCursor": "next-b", "previousCursor": None},
+        )
+
+        identifier_a, cursor_a, format_a = store.get_versions_followup(
+            "session-a", "next")
+        identifier_b, cursor_b, format_b = store.get_versions_followup(
+            "session-b", "next")
+
+        assert identifier_a == "doi:10.1234/example-a"
+        assert cursor_a == "next-a"
+        assert format_a == "summary"
+        assert identifier_b == "doi:10.1234/example-b"
+        assert cursor_b == "next-b"
+        assert format_b == "raw"
 
 
 class TestToolErrorPayload:

--- a/tests/unit/test_api_unit.py
+++ b/tests/unit/test_api_unit.py
@@ -881,6 +881,7 @@ class TestFormatResults:
             "result": [
                 {
                     "id": "ds1",
+                    "isPublic": True,
                     "dataset": {"name": "Dataset 1", "datePublished": "2024-01-01"},
                     "viewUrl": "https://example.com/ds1"
                 }
@@ -893,6 +894,7 @@ class TestFormatResults:
         assert isinstance(formatted, str)
         assert "Dataset 1" in formatted
         assert "ds1" in formatted
+        assert "isPublic: True" in formatted
 
     def test_format_results_summary_with_local_filtering(self):
         """Summary format should mention local metadata filtering when used."""
@@ -968,6 +970,10 @@ class TestFormatResults:
             "result": [
                 {
                     "id": "ds1",
+                    "isPublic": True,
+                    "dateUploaded": "2024-01-02T00:00:00Z",
+                    "dateModified": "2024-01-03T00:00:00Z",
+                    "citation": "Example dataset citation",
                     "dataset": {
                         "name": "Dataset 1",
                         "datePublished": "2024-01-01",
@@ -996,12 +1002,16 @@ class TestFormatResults:
         formatted = client.format_results(results, "detailed")
 
         assert "Alternate Names" in formatted
+        assert "isPublic: True" in formatted
+        assert "dateUploaded: 2024-01-02T00:00:00Z" in formatted
+        assert "dateModified: 2024-01-03T00:00:00Z" in formatted
         assert "Temporal Coverage: 2020-01-01 to 2020-12-31" in formatted
         assert "Spatial Coverage: Pennsylvania (41.0, -77.5)" in formatted
         assert "Variables Measured: snow water equivalent" in formatted
         assert "Measurement Techniques: Automated snow-depth sensor" in formatted
         assert "Funders: DOE" in formatted
         assert "License: https://creativecommons.org/licenses/by/4.0/" in formatted
+        assert "citation: Example dataset citation" in formatted
 
     def test_format_results_no_results(self):
         """Test formatting when no results are found."""
@@ -1012,6 +1022,55 @@ class TestFormatResults:
         formatted = client.format_results(results, "summary")
 
         assert "No results found" in formatted
+
+    def test_format_dataset_raw(self):
+        """Raw dataset format should return unchanged results."""
+        client = ESSDiveClient()
+        results = {"id": "ds1", "dataset": {"name": "Dataset 1"}, "isPublic": True}
+
+        formatted = client.format_dataset(results, "raw")
+
+        assert formatted == results
+
+    def test_format_dataset_detailed_includes_top_level_package_fields(self):
+        """Detailed dataset format should expose top-level package metadata."""
+        client = ESSDiveClient()
+
+        results = {
+            "id": "ds1",
+            "viewUrl": "https://example.com/ds1",
+            "dateUploaded": "2024-01-02T00:00:00Z",
+            "dateModified": "2024-01-03T00:00:00Z",
+            "isPublic": True,
+            "citation": "Example dataset citation",
+            "dataset": {
+                "name": "Dataset 1",
+                "@id": "doi:10.15485/example",
+                "datePublished": "2024-01-01",
+                "description": "A test dataset",
+                "distribution": [
+                    {
+                        "name": "data.csv",
+                        "contentSize": 12,
+                        "encodingFormat": "text/csv",
+                        "contentUrl": "https://example.com/data.csv",
+                        "identifier": "file-1",
+                    }
+                ],
+            },
+        }
+
+        formatted = client.format_dataset(results, "detailed")
+
+        assert "**id**: ds1" in formatted
+        assert "**doi**: doi:10.15485/example" in formatted
+        assert "**viewUrl**: https://example.com/ds1" in formatted
+        assert "**dateUploaded**: 2024-01-02T00:00:00Z" in formatted
+        assert "**dateModified**: 2024-01-03T00:00:00Z" in formatted
+        assert "**isPublic**: True" in formatted
+        assert "**citation**: Example dataset citation" in formatted
+        assert "## Data Files" in formatted
+        assert "data.csv" in formatted
 
     def test_format_dataset_versions_raw(self):
         """Raw version format should return unchanged results."""
@@ -1034,6 +1093,7 @@ class TestFormatResults:
             "result": [
                 {
                     "id": "ds-v2",
+                    "isPublic": True,
                     "viewUrl": "https://example.com/ds-v2",
                     "dateUploaded": "2026-01-01T00:00:00Z",
                     "dataset": {
@@ -1051,6 +1111,8 @@ class TestFormatResults:
         assert "Found 2 visible dataset versions" in formatted
         assert "nextCursor: next-cursor" in formatted
         assert "ds-v2" in formatted
+        assert "isPublic: True" in formatted
+        assert "dateUploaded: 2026-01-01T00:00:00Z" in formatted
 
     def test_format_dataset_versions_detailed(self):
         """Detailed version format should surface citation and neighbor links."""
@@ -1084,7 +1146,12 @@ class TestFormatResults:
 
         formatted = client.format_dataset_versions(results, "detailed")
 
-        assert "Example Citation" in formatted
+        assert "citation: Example Citation" in formatted
+        assert "isPublic: True" in formatted
+        assert "dateUploaded: 2026-01-01T00:00:00Z" in formatted
+        assert "dateModified: 2026-01-02T00:00:00Z" in formatted
+        assert "viewUrl: https://example.com/ds-v2" in formatted
+        assert "url: https://api.example.com/packages/ds-v2" in formatted
         assert "Newer Version URL" in formatted
         assert "Older Version URL" in formatted
 

--- a/tests/unit/test_api_unit.py
+++ b/tests/unit/test_api_unit.py
@@ -882,11 +882,15 @@ class TestFormatResults:
                 {
                     "id": "ds1",
                     "isPublic": True,
+                    "url": "https://api.example.com/packages/ds1",
+                    "previous": "https://api.example.com/packages/ds0",
+                    "next": "https://api.example.com/packages/ds2",
                     "dataset": {"name": "Dataset 1", "datePublished": "2024-01-01"},
                     "viewUrl": "https://example.com/ds1"
                 }
             ],
-            "total": 1
+            "total": 1,
+            "user": "anonymous",
         }
 
         formatted = client.format_results(results, "summary")
@@ -895,6 +899,11 @@ class TestFormatResults:
         assert "Dataset 1" in formatted
         assert "ds1" in formatted
         assert "isPublic: True" in formatted
+        assert "User: anonymous" in formatted
+        assert "viewUrl: https://example.com/ds1" in formatted
+        assert "url: https://api.example.com/packages/ds1" in formatted
+        assert "previous: https://api.example.com/packages/ds0" in formatted
+        assert "next: https://api.example.com/packages/ds2" in formatted
 
     def test_format_results_summary_with_local_filtering(self):
         """Summary format should mention local metadata filtering when used."""
@@ -971,6 +980,9 @@ class TestFormatResults:
                 {
                     "id": "ds1",
                     "isPublic": True,
+                    "url": "https://api.example.com/packages/ds1",
+                    "previous": "https://api.example.com/packages/ds0",
+                    "next": "https://api.example.com/packages/ds2",
                     "dateUploaded": "2024-01-02T00:00:00Z",
                     "dateModified": "2024-01-03T00:00:00Z",
                     "citation": "Example dataset citation",
@@ -992,25 +1004,43 @@ class TestFormatResults:
                         "measurementTechnique": ["Automated snow-depth sensor"],
                         "funder": [{"name": "DOE"}],
                         "license": "https://creativecommons.org/licenses/by/4.0/",
+                        "provider": {
+                            "name": "Example Program",
+                            "member": {
+                                "givenName": "Ada",
+                                "familyName": "Lovelace",
+                                "jobTitle": "principalInvestigator",
+                                "affiliation": "Example Lab",
+                            },
+                        },
+                        "award": ["DOE Award #12345"],
                     },
                     "viewUrl": "https://example.com/ds1",
                 }
             ],
             "total": 1,
+            "user": "anonymous",
         }
 
         formatted = client.format_results(results, "detailed")
 
         assert "Alternate Names" in formatted
         assert "isPublic: True" in formatted
+        assert "User: anonymous" in formatted
         assert "dateUploaded: 2024-01-02T00:00:00Z" in formatted
         assert "dateModified: 2024-01-03T00:00:00Z" in formatted
+        assert "viewUrl: https://example.com/ds1" in formatted
+        assert "url: https://api.example.com/packages/ds1" in formatted
+        assert "previous: https://api.example.com/packages/ds0" in formatted
+        assert "next: https://api.example.com/packages/ds2" in formatted
         assert "Temporal Coverage: 2020-01-01 to 2020-12-31" in formatted
         assert "Spatial Coverage: Pennsylvania (41.0, -77.5)" in formatted
         assert "Variables Measured: snow water equivalent" in formatted
         assert "Measurement Techniques: Automated snow-depth sensor" in formatted
         assert "Funders: DOE" in formatted
         assert "License: https://creativecommons.org/licenses/by/4.0/" in formatted
+        assert "Provider: Example Program (Ada Lovelace, principalInvestigator, Example Lab)" in formatted
+        assert "Award: DOE Award #12345" in formatted
         assert "citation: Example dataset citation" in formatted
 
     def test_format_results_no_results(self):
@@ -1039,6 +1069,9 @@ class TestFormatResults:
         results = {
             "id": "ds1",
             "viewUrl": "https://example.com/ds1",
+            "url": "https://api.example.com/packages/ds1",
+            "previous": "https://api.example.com/packages/ds0",
+            "next": "https://api.example.com/packages/ds2",
             "dateUploaded": "2024-01-02T00:00:00Z",
             "dateModified": "2024-01-03T00:00:00Z",
             "isPublic": True,
@@ -1048,6 +1081,16 @@ class TestFormatResults:
                 "@id": "doi:10.15485/example",
                 "datePublished": "2024-01-01",
                 "description": "A test dataset",
+                "provider": {
+                    "name": "Example Program",
+                    "member": {
+                        "givenName": "Ada",
+                        "familyName": "Lovelace",
+                        "jobTitle": "principalInvestigator",
+                        "affiliation": "Example Lab",
+                    },
+                },
+                "award": ["DOE Award #12345"],
                 "distribution": [
                     {
                         "name": "data.csv",
@@ -1065,10 +1108,17 @@ class TestFormatResults:
         assert "**id**: ds1" in formatted
         assert "**doi**: doi:10.15485/example" in formatted
         assert "**viewUrl**: https://example.com/ds1" in formatted
+        assert "**url**: https://api.example.com/packages/ds1" in formatted
+        assert "**previous**: https://api.example.com/packages/ds0" in formatted
+        assert "**next**: https://api.example.com/packages/ds2" in formatted
         assert "**dateUploaded**: 2024-01-02T00:00:00Z" in formatted
         assert "**dateModified**: 2024-01-03T00:00:00Z" in formatted
         assert "**isPublic**: True" in formatted
         assert "**citation**: Example dataset citation" in formatted
+        assert "## Provider" in formatted
+        assert "Example Program (Ada Lovelace, principalInvestigator, Example Lab)" in formatted
+        assert "## Award" in formatted
+        assert "DOE Award #12345" in formatted
         assert "## Data Files" in formatted
         assert "data.csv" in formatted
 
@@ -1090,11 +1140,15 @@ class TestFormatResults:
             "pageSize": 2,
             "nextCursor": "next-cursor",
             "previousCursor": None,
+            "user": "anonymous",
             "result": [
                 {
                     "id": "ds-v2",
                     "isPublic": True,
                     "viewUrl": "https://example.com/ds-v2",
+                    "url": "https://api.example.com/packages/ds-v2",
+                    "previous": "https://api.example.com/packages/ds-v1",
+                    "next": "https://api.example.com/packages/ds-v3",
                     "dateUploaded": "2026-01-01T00:00:00Z",
                     "dataset": {
                         "name": "Dataset 1 v2",
@@ -1109,10 +1163,14 @@ class TestFormatResults:
 
         assert isinstance(formatted, str)
         assert "Found 2 visible dataset versions" in formatted
+        assert "User: anonymous" in formatted
         assert "nextCursor: next-cursor" in formatted
         assert "ds-v2" in formatted
         assert "isPublic: True" in formatted
         assert "dateUploaded: 2026-01-01T00:00:00Z" in formatted
+        assert "url: https://api.example.com/packages/ds-v2" in formatted
+        assert "previous: https://api.example.com/packages/ds-v1" in formatted
+        assert "next: https://api.example.com/packages/ds-v3" in formatted
 
     def test_format_dataset_versions_detailed(self):
         """Detailed version format should surface citation and neighbor links."""
@@ -1123,6 +1181,7 @@ class TestFormatResults:
             "pageSize": 1,
             "nextCursor": None,
             "previousCursor": None,
+            "user": "anonymous",
             "result": [
                 {
                     "id": "ds-v2",
@@ -1146,12 +1205,15 @@ class TestFormatResults:
 
         formatted = client.format_dataset_versions(results, "detailed")
 
+        assert "User: anonymous" in formatted
         assert "citation: Example Citation" in formatted
         assert "isPublic: True" in formatted
         assert "dateUploaded: 2026-01-01T00:00:00Z" in formatted
         assert "dateModified: 2026-01-02T00:00:00Z" in formatted
         assert "viewUrl: https://example.com/ds-v2" in formatted
         assert "url: https://api.example.com/packages/ds-v2" in formatted
+        assert "previous: https://api.example.com/packages/ds-v1" in formatted
+        assert "next: https://api.example.com/packages/ds-v3" in formatted
         assert "Newer Version URL" in formatted
         assert "Older Version URL" in formatted
 


### PR DESCRIPTION
This pull request updates the ESS-DIVE datasets skill documentation and integration tests to clarify and expand support for paginated dataset search, version history, and status checking. It introduces new stateful pagination tools, explains when to use raw versus summarized formats, and adds examples and test assertions for these features.

**Documentation and Tooling Enhancements:**

* Added new stateful pagination tools: `next-search-page`, `previous-search-page`, `next-dataset-versions-page`, and `previous-dataset-versions-page` for conversational navigation of search and version history results without requiring the caller to handle cursors directly. [[1]](diffhunk://#diff-93e348e1d93021edeba93a583afc55ebe4b3d78cff9e6d4c7a327c8995e05fa2R50-R56) [[2]](diffhunk://#diff-93e348e1d93021edeba93a583afc55ebe4b3d78cff9e6d4c7a327c8995e05fa2R104-R127) [[3]](diffhunk://#diff-93e348e1d93021edeba93a583afc55ebe4b3d78cff9e6d4c7a327c8995e05fa2R212-R227) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R722-R737) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R913-R919)
* Introduced the `get-dataset-status` tool for checking dataset publication/workflow status, with guidance on when to use it and handling authentication requirements. [[1]](diffhunk://#diff-93e348e1d93021edeba93a583afc55ebe4b3d78cff9e6d4c7a327c8995e05fa2R187-R199) [[2]](diffhunk://#diff-93e348e1d93021edeba93a583afc55ebe4b3d78cff9e6d4c7a327c8995e05fa2R255-R268) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R722-R737) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R913-R919)

**Usage Guidance and Examples:**

* Expanded documentation with clear instructions and examples for paginating search and version results, including when to use raw mode, how to handle cursors, and how to summarize paginated data. [[1]](diffhunk://#diff-93e348e1d93021edeba93a583afc55ebe4b3d78cff9e6d4c7a327c8995e05fa2R104-R127) [[2]](diffhunk://#diff-93e348e1d93021edeba93a583afc55ebe4b3d78cff9e6d4c7a327c8995e05fa2R255-R268) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R856-R857) [[4]](diffhunk://#diff-575f437adbaa0a0d03dcb09786421ad76982aa9798df84a162fb13fc681d7ea2R129-R134)
* Updated usage examples in `README.md` and `docs/SKILLS.md` to demonstrate new pagination and status-checking flows, both with and without exposing cursor values. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R856-R857) [[2]](diffhunk://#diff-575f437adbaa0a0d03dcb09786421ad76982aa9798df84a162fb13fc681d7ea2R129-R134)

**Testing Improvements:**

* Added integration test assertions to verify that the `isPublic` field is present and boolean in search and version results, ensuring consistency with the documented API responses. [[1]](diffhunk://#diff-21489fd9028f86e5a018aed573522397237612ae17716ab50d5383f128548ad8R71) [[2]](diffhunk://#diff-21489fd9028f86e5a018aed573522397237612ae17716ab50d5383f128548ad8R125) [[3]](diffhunk://#diff-21489fd9028f86e5a018aed573522397237612ae17716ab50d5383f128548ad8R181)

**Other Notable Changes:**

* Clarified the skill description to mention status fetching and improved notes on pagination and result formats. [[1]](diffhunk://#diff-93e348e1d93021edeba93a583afc55ebe4b3d78cff9e6d4c7a327c8995e05fa2L3-R3) [[2]](diffhunk://#diff-93e348e1d93021edeba93a583afc55ebe4b3d78cff9e6d4c7a327c8995e05fa2R255-R268)

These changes make the ESS-DIVE datasets skill easier to use for conversational agents, improve documentation clarity, and ensure robust test coverage for new and existing features.