### PR TITLE
Add ESS-DIVE data citation tool

### DIFF
--- a/.agents/skills/essdeepdive/SKILL.md
+++ b/.agents/skills/essdeepdive/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: essdeepdive
-description: Query the ESS-DeepDive fusion database for fields and file metadata via MCP tools.
+description: Query the ESS-DeepDive fusion database for fields and file metadata, and generate citations for linked ESS-DIVE datasets via MCP tools.
 ---
 
 # Setup (once)
@@ -37,6 +37,7 @@ claude mcp add --transport stdio essdive-mcp -- uv run python ./src/essdive_mcp/
 - `search-ess-deepdive`
 - `get-ess-deepdive-dataset`
 - `get-ess-deepdive-file`
+- `generate-data-citation`
 - `lookup-project-portal`
 - `coords-to-map-links`
 
@@ -66,6 +67,12 @@ Get full file metadata and download info:
 get-ess-deepdive-file with doi="doi:10.15485/2453885" and file_path="dataset.zip/data.csv"
 ```
 
+Generate a citation for a dataset DOI found in ESS-DeepDive results:
+
+```
+generate-data-citation with id="doi:10.15485/2453885" and access_date="2026-05-06"
+```
+
 Look up a project acronym and its portal details:
 
 ```
@@ -82,4 +89,6 @@ coords-to-map-links with points=[[38.9219, -106.9490]] and zoom=12
 
 - `row_start` is 1-based. Use `max_pages` for automatic pagination.
 - `doi` may be provided as `10.xxxx/...` or `doi:10.xxxx/...`.
+- When a user asks for citable sources, report dataset-level citations with `generate-data-citation` using the DOI from ESS-DeepDive results.
+- Do not cite individual ESS-DeepDive field records as if they were standalone datasets; cite the linked ESS-DIVE dataset DOI.
 - For portal names, acronyms, and URLs, consult `../references/essdive_project_portals.yaml`.

--- a/.agents/skills/essdive-data-citations/SKILL.md
+++ b/.agents/skills/essdive-data-citations/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: essdive-data-citations
+description: Generate consistent ESS-DIVE data citations with repository, project/provider, DOI, and MCP/API access details from dataset IDs, DOIs, or metadata.
+---
+
+# Setup (once)
+
+Run the MCP server locally:
+
+```bash
+uv run python src/essdive_mcp/main.py
+```
+
+If you need authenticated/private-data access, provide a token explicitly:
+
+```bash
+uv run python src/essdive_mcp/main.py --token YOUR_ESS_DIVE_TOKEN_HERE
+```
+
+Or provide the token via a file:
+
+```bash
+uv run python src/essdive_mcp/main.py --token-file /path/to/token.txt
+```
+
+Note: the environment variable name is `ESSDIVE_API_TOKEN` (no underscore
+between ESS and DIVE).
+
+Register with Claude Code (stdio transport):
+
+```bash
+claude mcp add --transport stdio essdive-mcp -- uv run python ./src/essdive_mcp/main.py
+```
+
+If you need authenticated/private-data access, add a token:
+
+```bash
+claude mcp add --transport stdio essdive-mcp --env ESSDIVE_API_TOKEN=YOUR_ESS_DIVE_TOKEN_HERE -- uv run python ./src/essdive_mcp/main.py
+```
+
+# Tools
+
+- `generate-data-citation`
+- `get-dataset`
+- `doi-to-essdive-id`
+- `essdive-id-to-doi`
+
+## Usage examples
+
+Generate a citation from a DOI:
+
+```
+generate-data-citation with id="doi:10.15485/3014404"
+```
+
+Generate a reproducible citation with an explicit access date:
+
+```
+generate-data-citation with id="doi:10.15485/3014404" and access_date="2026-05-06"
+```
+
+Override the default access method when the citation should describe another
+workflow:
+
+```
+generate-data-citation with id="doi:10.15485/3014404" and access_date="2026-05-06" and access_method="custom export workflow"
+```
+
+Use already-fetched metadata instead of requesting the dataset again:
+
+```
+get-dataset with id="doi:10.15485/3014404" and format="raw"
+generate-data-citation with dataset_metadata=PASTE_RAW_DATASET_METADATA and access_date="2026-05-06"
+```
+
+## Expected output shape
+
+The citation should follow this shape:
+
+```text
+Creator Family Initials ; Creator Family Initials (YEAR): Dataset title. Provider, ESS-DIVE repository. Dataset. doi:10.xxxx/xxxx accessed via ESS-DIVE API over ESS-DIVE MCP on YYYY-MM-DD
+```
+
+Example:
+
+```text
+Breckheimer I ; Carroll E ; Chadwick K D ; Falco N ; Henderson A ; Lovegreen P ; O'Ryan D ; Todorov S ; Villa A ; Williams C ; Worsham H M ; Xu H (2026): CHESS 2025: Field-collected vegetation attributes and site photos. Watershed Function SFA, ESS-DIVE repository. Dataset. doi:10.15485/3014404 accessed via ESS-DIVE API over ESS-DIVE MCP on 2026-05-06
+```
+
+## Notes
+
+- Prefer `generate-data-citation` whenever the user asks how to cite an ESS-DIVE dataset or when an export/report should include a dataset citation.
+- Pass `access_date` when the output needs to be reproducible. Otherwise the tool uses the MCP server's current date.
+- The default access phrase is `ESS-DIVE API over ESS-DIVE MCP`.
+- `id` may be an ESS-DIVE package ID or a DOI in common DOI forms.
+- If another workflow already has the raw `get-dataset` payload, pass it as `dataset_metadata` to avoid an extra API request.
+- Use `doi-to-essdive-id` or `essdive-id-to-doi` first only when the user explicitly needs identifier conversion; `generate-data-citation` can fetch citation metadata directly from either a package ID or DOI.
+
+## Fallback (no MCP server)
+
+If the MCP server is unavailable, fetch the dataset metadata from the ESS-DIVE
+API and construct the same citation shape from `dataset.creator`,
+`dataset.datePublished`, `dataset.name`, `dataset.provider.name`, and
+`dataset.@id`:
+
+```bash
+curl -sG "https://api.ess-dive.lbl.gov/packages/doi%3A10.15485%2F3014404" \
+  -H "Accept: application/json" \
+  -H "User-Agent: Mozilla/5.0" \
+  -H "Range: bytes=0-1000" \
+  --data-urlencode "isPublic=true"
+```

--- a/.agents/skills/essdive-data-citations/SKILL.md
+++ b/.agents/skills/essdive-data-citations/SKILL.md
@@ -112,6 +112,7 @@ Kucsko G ; Maurer P C ; Yao N Y ; Kubo M ; Noh H J ; Lo P K ; Park H ; Lukin M D
 - The default access phrase is `ESS-DIVE API over ESS-DIVE MCP`.
 - `id` may be an ESS-DIVE package ID or a DOI in common DOI forms.
 - If another workflow already has the raw `get-dataset` payload, pass it as `dataset_metadata` to avoid an extra API request.
+- If `dataset_metadata` contains a non-ESS-DIVE DOI, the tool should still warn and avoid labeling it as an ESS-DIVE repository citation.
 - Use `doi-to-essdive-id` or `essdive-id-to-doi` first only when the user explicitly needs identifier conversion; `generate-data-citation` can fetch citation metadata directly from either a package ID or DOI.
 - For non-ESS-DIVE DOIs, preserve the warning in the final answer so the user can notice that a non-ESS-DIVE reference is present.
 - Invalid or unknown DOIs should return an error rather than a fabricated citation.

--- a/.agents/skills/essdive-data-citations/SKILL.md
+++ b/.agents/skills/essdive-data-citations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: essdive-data-citations
-description: Generate consistent ESS-DIVE data citations with repository, project/provider, DOI, and MCP/API access details from dataset IDs, DOIs, or metadata.
+description: Generate consistent ESS-DIVE data citations with repository, project/provider, DOI, and MCP/API access details from dataset IDs, DOIs, or metadata; warn and use Crossref fallback for non-ESS-DIVE DOIs.
 ---
 
 # Setup (once)
@@ -45,6 +45,9 @@ claude mcp add --transport stdio essdive-mcp --env ESSDIVE_API_TOKEN=YOUR_ESS_DI
 - `doi-to-essdive-id`
 - `essdive-id-to-doi`
 
+The Crossref fallback is internal to `generate-data-citation`; there is no
+separate Crossref MCP tool to call.
+
 ## Usage examples
 
 Generate a citation from a DOI:
@@ -73,6 +76,12 @@ get-dataset with id="doi:10.15485/3014404" and format="raw"
 generate-data-citation with dataset_metadata=PASTE_RAW_DATASET_METADATA and access_date="2026-05-06"
 ```
 
+Generate a warning-backed citation for a non-ESS-DIVE DOI:
+
+```
+generate-data-citation with id="doi:10.1038/nature12373" and access_date="2026-05-06"
+```
+
 ## Expected output shape
 
 The citation should follow this shape:
@@ -87,6 +96,15 @@ Example:
 Breckheimer I ; Carroll E ; Chadwick K D ; Falco N ; Henderson A ; Lovegreen P ; O'Ryan D ; Todorov S ; Villa A ; Williams C ; Worsham H M ; Xu H (2026): CHESS 2025: Field-collected vegetation attributes and site photos. Watershed Function SFA, ESS-DIVE repository. Dataset. doi:10.15485/3014404 accessed via ESS-DIVE API over ESS-DIVE MCP on 2026-05-06
 ```
 
+If the DOI is not an ESS-DIVE DOI, the output should start with a warning and
+then use Crossref metadata:
+
+```text
+WARNING: doi:10.1038/nature12373 is not an ESS-DIVE DOI; citation was generated from Crossref metadata and may not describe an ESS-DIVE dataset.
+
+Kucsko G ; Maurer P C ; Yao N Y ; Kubo M ; Noh H J ; Lo P K ; Park H ; Lukin M D (2013): Nanometre-scale thermometry in a living cell. Nature. Journal article. doi:10.1038/nature12373 accessed via Crossref API over ESS-DIVE MCP on 2026-05-06
+```
+
 ## Notes
 
 - Prefer `generate-data-citation` whenever the user asks how to cite an ESS-DIVE dataset or when an export/report should include a dataset citation.
@@ -95,6 +113,8 @@ Breckheimer I ; Carroll E ; Chadwick K D ; Falco N ; Henderson A ; Lovegreen P ;
 - `id` may be an ESS-DIVE package ID or a DOI in common DOI forms.
 - If another workflow already has the raw `get-dataset` payload, pass it as `dataset_metadata` to avoid an extra API request.
 - Use `doi-to-essdive-id` or `essdive-id-to-doi` first only when the user explicitly needs identifier conversion; `generate-data-citation` can fetch citation metadata directly from either a package ID or DOI.
+- For non-ESS-DIVE DOIs, preserve the warning in the final answer so the user can notice that a non-ESS-DIVE reference is present.
+- Invalid or unknown DOIs should return an error rather than a fabricated citation.
 
 ## Fallback (no MCP server)
 

--- a/.agents/skills/essdive-datasets/SKILL.md
+++ b/.agents/skills/essdive-datasets/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: essdive-datasets
-description: Search ESS-DIVE datasets, fetch metadata/version history/status/permissions, and parse FLMD via MCP tools.
+description: Search ESS-DIVE datasets, fetch metadata/version history/status/permissions, generate dataset citations, and parse FLMD via MCP tools.
 ---
 
 # Setup (once)
@@ -50,6 +50,7 @@ claude mcp add --transport stdio essdive-mcp -- uv run python ./src/essdive_mcp/
 - `next-search-page`
 - `previous-search-page`
 - `get-dataset`
+- `generate-data-citation`
 - `get-dataset-versions`
 - `next-dataset-versions-page`
 - `previous-dataset-versions-page`
@@ -191,6 +192,18 @@ Return the raw dataset payload when you need exact top-level API fields such as
 get-dataset with id="doi:10.15485/2529445" and format="raw"
 ```
 
+Generate a consistent data citation for a dataset:
+
+```
+generate-data-citation with id="doi:10.15485/3014404"
+```
+
+Use an explicit access date for reproducible exports or reports:
+
+```
+generate-data-citation with id="doi:10.15485/3014404" and access_date="2026-05-06"
+```
+
 Check publication/workflow status for a dataset:
 
 ```
@@ -256,6 +269,9 @@ coords-to-map-links with bbox=[38.9187, -106.9532, 38.9263, -106.9451]
 - If the user asks for the status of multiple datasets, call `get-dataset-status` once per dataset identifier and summarize the results.
 - `get-dataset-status` may require an ESS-DIVE API token and dataset access. If an anonymous call fails, explain that status is auth-gated.
 - `get-dataset` supports `format="raw"` when you need the exact response fields, including top-level `isPublic`.
+- Use `generate-data-citation` when the user asks how to cite a dataset or when an export/report should include an ESS-DIVE data citation.
+- `generate-data-citation` accepts an `id` or an already-fetched raw `dataset_metadata` object. Prefer passing `dataset_metadata` when the workflow already called `get-dataset` with `format="raw"`.
+- Pass `access_date` when citation output must be reproducible; otherwise the MCP server uses its current date.
 - `page_size` max is 100.
 - `cursor` is the preferred way to page through search results. `row_start` is still supported for compatibility but is legacy.
 - Search and version responses include an integer `total` plus `nextCursor` and `previousCursor` when pagination is available.

--- a/.agents/skills/essdive-datasets/SKILL.md
+++ b/.agents/skills/essdive-datasets/SKILL.md
@@ -272,6 +272,7 @@ coords-to-map-links with bbox=[38.9187, -106.9532, 38.9263, -106.9451]
 - Use `generate-data-citation` when the user asks how to cite a dataset or when an export/report should include an ESS-DIVE data citation.
 - `generate-data-citation` accepts an `id` or an already-fetched raw `dataset_metadata` object. Prefer passing `dataset_metadata` when the workflow already called `get-dataset` with `format="raw"`.
 - Pass `access_date` when citation output must be reproducible; otherwise the MCP server uses its current date.
+- If `generate-data-citation` warns that a DOI is not from ESS-DIVE, preserve that warning in the final answer.
 - `page_size` max is 100.
 - `cursor` is the preferred way to page through search results. `row_start` is still supported for compatibility but is legacy.
 - Search and version responses include an integer `total` plus `nextCursor` and `previousCursor` when pagination is available.

--- a/.agents/skills/essdive-identifiers/SKILL.md
+++ b/.agents/skills/essdive-identifiers/SKILL.md
@@ -78,6 +78,7 @@ coords-to-map-links with points=[[38.9219, -106.9490]] and zoom=12
 - Outputs return a normalized DOI format.
 - Prefer `generate-data-citation` when the user asks for a citable reference rather than just an identifier conversion.
 - `generate-data-citation` can fetch citation metadata directly from either a package ID or DOI, so do not add a separate conversion step unless the user also wants the converted identifier.
+- If `generate-data-citation` warns that a DOI is not from ESS-DIVE, preserve that warning in the final answer.
 - For portal names, acronyms, and URLs, consult `../references/essdive_project_portals.yaml`.
 
 ## Fallback (no MCP server)

--- a/.agents/skills/essdive-identifiers/SKILL.md
+++ b/.agents/skills/essdive-identifiers/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: essdive-identifiers
-description: Convert between ESS-DIVE dataset IDs and DOIs via MCP tools.
+description: Convert between ESS-DIVE dataset IDs and DOIs, and generate ESS-DIVE data citations from either identifier via MCP tools.
 ---
 
 # Setup (once)
@@ -36,6 +36,7 @@ claude mcp add --transport stdio essdive-mcp -- uv run python ./src/essdive_mcp/
 
 - `doi-to-essdive-id`
 - `essdive-id-to-doi`
+- `generate-data-citation`
 - `lookup-project-portal`
 - `coords-to-map-links`
 
@@ -51,6 +52,12 @@ Convert an ESS-DIVE ID to a DOI:
 
 ```
 essdive-id-to-doi with essdive_id="ess-dive-9ea5fe57db73c90-20241024T093714082510"
+```
+
+Generate a data citation directly from a DOI or ESS-DIVE ID:
+
+```
+generate-data-citation with id="doi:10.15485/3014404" and access_date="2026-05-06"
 ```
 
 Look up a project acronym and its portal details:
@@ -69,6 +76,8 @@ coords-to-map-links with points=[[38.9219, -106.9490]] and zoom=12
 
 - DOI inputs can include prefixes or URLs (e.g., `doi:10.15485/...` or `https://doi.org/...`).
 - Outputs return a normalized DOI format.
+- Prefer `generate-data-citation` when the user asks for a citable reference rather than just an identifier conversion.
+- `generate-data-citation` can fetch citation metadata directly from either a package ID or DOI, so do not add a separate conversion step unless the user also wants the converted identifier.
 - For portal names, acronyms, and URLs, consult `../references/essdive_project_portals.yaml`.
 
 ## Fallback (no MCP server)

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,8 +5,8 @@
     "email": "jhc@lbl.gov"
   },
   "metadata": {
-    "description": "Skills for ESS-DIVE dataset search, identifier conversion, and ESS-DeepDive queries",
-    "version": "0.2.4"
+    "description": "Skills for ESS-DIVE dataset search, citation generation, identifier conversion, and ESS-DeepDive queries",
+    "version": "0.2.5"
   },
   "plugins": [
     {
@@ -16,6 +16,15 @@
       "strict": false,
       "skills": [
         "../.agents/skills/essdive-datasets"
+      ]
+    },
+    {
+      "name": "essdive-data-citations",
+      "description": "Generate consistent ESS-DIVE data citations",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "../.agents/skills/essdive-data-citations"
       ]
     },
     {

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ This project gives an AI client a set of tools for:
 - searching public ESS-DIVE datasets
 - fetching dataset metadata, version history, and sharing permissions
 - converting between ESS-DIVE dataset IDs and DOIs
+- generating consistent ESS-DIVE data citations with MCP/API access details
 - parsing File Level Metadata (FLMD) CSV content
 - searching ESS-DeepDive field and file metadata
 - looking up ESS-DIVE project acronyms, descriptions, and portal URLs
@@ -740,6 +741,8 @@ search-datasets with query="East River" and variable_measured="streamflow" and p
 search-datasets with query="East River" and funder="NASA" and page_size=5
 get-dataset with id="ess-dive-165671432ae620e-20250908T210722395"
 get-dataset with id="doi:10.15485/2529445" and format="raw"
+generate-data-citation with id="doi:10.15485/3014404"
+generate-data-citation with id="doi:10.15485/3014404" and access_date="2026-05-06"
 get-dataset-versions with id="doi:10.15485/2529445" and page_size=2
 get-dataset-versions with id="doi:10.15485/2529445" and cursor="PASTE_NEXT_CURSOR_HERE"
 next-dataset-versions-page
@@ -923,6 +926,7 @@ and the observed values range from 19.1 to 26.9 C.
 - `next-search-page`
 - `previous-search-page`
 - `get-dataset`
+- `generate-data-citation`
 - `get-dataset-versions`
 - `next-dataset-versions-page`
 - `previous-dataset-versions-page`

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ This project gives an AI client a set of tools for:
 - searching public ESS-DIVE datasets
 - fetching dataset metadata, version history, and sharing permissions
 - converting between ESS-DIVE dataset IDs and DOIs
-- generating consistent ESS-DIVE data citations with MCP/API access details
+- generating consistent ESS-DIVE data citations with MCP/API access details, plus warning-backed Crossref fallback for non-ESS-DIVE DOIs
 - parsing File Level Metadata (FLMD) CSV content
 - searching ESS-DeepDive field and file metadata
 - looking up ESS-DIVE project acronyms, descriptions, and portal URLs
@@ -743,6 +743,7 @@ get-dataset with id="ess-dive-165671432ae620e-20250908T210722395"
 get-dataset with id="doi:10.15485/2529445" and format="raw"
 generate-data-citation with id="doi:10.15485/3014404"
 generate-data-citation with id="doi:10.15485/3014404" and access_date="2026-05-06"
+generate-data-citation with id="doi:10.1038/nature12373" and access_date="2026-05-06"
 get-dataset-versions with id="doi:10.15485/2529445" and page_size=2
 get-dataset-versions with id="doi:10.15485/2529445" and cursor="PASTE_NEXT_CURSOR_HERE"
 next-dataset-versions-page

--- a/README.md
+++ b/README.md
@@ -760,6 +760,7 @@ coords-to-map-links with points=[[38.9219, -106.9490]] and zoom=12
 Skills are optional. They are useful when you want an agent to consistently recognize a recurring task pattern, such as:
 
 - dataset discovery and metadata follow-up
+- data citation generation
 - DOI and ESS-DIVE ID conversion
 - ESS-DeepDive field and file exploration
 
@@ -772,10 +773,11 @@ What is a Skill?
 
 You can also use the Skills without installing this MCP server. In that case, they still provide task-specific instructions and prompt patterns, and some of them include fallback API examples. You just will not get the full MCP tool integration.
 
-This repository includes three Skills described in [docs/SKILLS.md](docs/SKILLS.md):
+This repository includes four Skills described in [docs/SKILLS.md](docs/SKILLS.md):
 
 - `essdive-datasets`
 - `essdive-identifiers`
+- `essdive-data-citations`
 - `essdeepdive`
 
 ### Quick Start for Skills in Goose Desktop
@@ -807,6 +809,7 @@ For the easiest install, copy this repository's Skill tree into one of Goose's s
 .agents/skills/
   essdive-datasets/SKILL.md
   essdive-identifiers/SKILL.md
+  essdive-data-citations/SKILL.md
   essdeepdive/SKILL.md
   references/essdive_project_portals.yaml
 ```
@@ -820,6 +823,7 @@ If you prefer to create the files manually, create these directories and then co
 
 - [SKILL.md](/home/harry/essdive-mcp/.agents/skills/essdive-datasets/SKILL.md)
 - [SKILL.md](/home/harry/essdive-mcp/.agents/skills/essdive-identifiers/SKILL.md)
+- [SKILL.md](/home/harry/essdive-mcp/.agents/skills/essdive-data-citations/SKILL.md)
 - [SKILL.md](/home/harry/essdive-mcp/.agents/skills/essdeepdive/SKILL.md)
 - [essdive_project_portals.yaml](/home/harry/essdive-mcp/.agents/skills/references/essdive_project_portals.yaml)
 
@@ -870,6 +874,7 @@ Examples:
 - `Use the essdive-datasets skill to search for BIONTE datasets and then show me the next page without exposing the cursor values.`
 - `Use the essdive-datasets skill to list the version history for DOI 10.15485/2529445 and summarize the newest two versions.`
 - `Use the essdive-identifiers skill to normalize DOI https://doi.org/10.15485/2587853 and return the ESS-DIVE ID.`
+- `Use the essdive-data-citations skill to generate a citation for DOI 10.15485/3014404 with access date 2026-05-06.`
 - `Use the essdeepdive skill to search for temperature fields and tell me which data file each result comes from.`
 
 ### Skill result examples

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -13,6 +13,7 @@ A Skill is a reusable instruction document that helps an AI agent handle a recur
 In this repository, the Skills help an agent:
 
 - search ESS-DIVE datasets
+- generate consistent ESS-DIVE data citations
 - convert between DOIs and ESS-DIVE IDs
 - query ESS-DeepDive field and file metadata
 - resolve ESS-DIVE project acronyms and portal URLs from a shared local reference file
@@ -83,6 +84,14 @@ Convert between ESS-DIVE dataset IDs and DOIs.
 
 See [`../.agents/skills/essdive-identifiers/SKILL.md`](../.agents/skills/essdive-identifiers/SKILL.md).
 
+### `essdive-data-citations`
+
+Generate consistent ESS-DIVE data citations from dataset IDs, DOIs, or raw
+dataset metadata, including provider, ESS-DIVE repository, DOI, and MCP/API
+access details.
+
+See [`../.agents/skills/essdive-data-citations/SKILL.md`](../.agents/skills/essdive-data-citations/SKILL.md).
+
 ### `essdeepdive`
 
 Query the ESS-DeepDive fusion database for fields and file metadata.
@@ -91,7 +100,9 @@ See [`../.agents/skills/essdeepdive/SKILL.md`](../.agents/skills/essdeepdive/SKI
 
 ### Shared mapping helper
 
-All three Skills also reference `coords-to-map-links` for turning points or bounding boxes into links for tools such as geojson.io and OpenStreetMap.
+The dataset, identifier, and ESS-DeepDive Skills also reference
+`coords-to-map-links` for turning points or bounding boxes into links for tools
+such as geojson.io and OpenStreetMap.
 
 ## Install In Claude Code
 
@@ -139,6 +150,11 @@ To remove them:
 
 - `Use the essdive-identifiers skill to convert DOI 10.15485/2587853 to an ESS-DIVE dataset ID.`
 - `Use the essdive-identifiers skill to normalize https://doi.org/10.15485/2587853 and return the DOI and dataset ID.`
+
+### `essdive-data-citations`
+
+- `Use the essdive-data-citations skill to generate a citation for DOI 10.15485/3014404.`
+- `Use the essdive-data-citations skill to generate a citation for DOI 10.15485/3014404 with access date 2026-05-06.`
 
 ### `essdeepdive`
 

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -88,7 +88,8 @@ See [`../.agents/skills/essdive-identifiers/SKILL.md`](../.agents/skills/essdive
 
 Generate consistent ESS-DIVE data citations from dataset IDs, DOIs, or raw
 dataset metadata, including provider, ESS-DIVE repository, DOI, and MCP/API
-access details.
+access details. For non-ESS-DIVE DOIs, the Skill tells agents to preserve the
+warning and use Crossref-derived citation metadata when available.
 
 See [`../.agents/skills/essdive-data-citations/SKILL.md`](../.agents/skills/essdive-data-citations/SKILL.md).
 

--- a/scripts/install_codex_skills.sh
+++ b/scripts/install_codex_skills.sh
@@ -5,7 +5,14 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CODEX_SKILLS_DIR="${CODEX_HOME:-$HOME/.codex}/skills"
 SOURCE_SKILLS_DIR="$ROOT_DIR/.agents/skills"
 
-for skill in essdive-datasets essdive-identifiers essdeepdive; do
+SKILLS=(
+  essdive-datasets
+  essdive-identifiers
+  essdive-data-citations
+  essdeepdive
+)
+
+for skill in "${SKILLS[@]}"; do
   if [[ ! -f "$SOURCE_SKILLS_DIR/$skill/SKILL.md" ]]; then
     echo "Missing SKILL.md for $skill at $SOURCE_SKILLS_DIR/$skill/SKILL.md" >&2
     exit 1
@@ -14,8 +21,8 @@ done
 
 mkdir -p "$CODEX_SKILLS_DIR"
 
-ln -sfn "$SOURCE_SKILLS_DIR/essdive-datasets" "$CODEX_SKILLS_DIR/essdive-datasets"
-ln -sfn "$SOURCE_SKILLS_DIR/essdive-identifiers" "$CODEX_SKILLS_DIR/essdive-identifiers"
-ln -sfn "$SOURCE_SKILLS_DIR/essdeepdive" "$CODEX_SKILLS_DIR/essdeepdive"
+for skill in "${SKILLS[@]}"; do
+  ln -sfn "$SOURCE_SKILLS_DIR/$skill" "$CODEX_SKILLS_DIR/$skill"
+done
 
 echo "Installed Codex skills into: $CODEX_SKILLS_DIR"

--- a/scripts/uninstall_codex_skills.sh
+++ b/scripts/uninstall_codex_skills.sh
@@ -3,8 +3,15 @@ set -euo pipefail
 
 CODEX_SKILLS_DIR="${CODEX_HOME:-$HOME/.codex}/skills"
 
-rm -f "$CODEX_SKILLS_DIR/essdive-datasets"
-rm -f "$CODEX_SKILLS_DIR/essdive-identifiers"
-rm -f "$CODEX_SKILLS_DIR/essdeepdive"
+SKILLS=(
+  essdive-datasets
+  essdive-identifiers
+  essdive-data-citations
+  essdeepdive
+)
+
+for skill in "${SKILLS[@]}"; do
+  rm -f "$CODEX_SKILLS_DIR/$skill"
+done
 
 echo "Removed Codex skill links from: $CODEX_SKILLS_DIR"

--- a/src/essdive_mcp/main.py
+++ b/src/essdive_mcp/main.py
@@ -34,6 +34,10 @@ MCP Tools Available:
   - parse-flmd-file: Parse File Level Metadata (FLMD) CSV files to extract filename and
     description mappings for dataset files.
 
+**Export Helpers:**
+  - generate-data-citation: Generate a consistent ESS-DIVE data citation with
+    repository and MCP/API access details for a dataset ID or provided metadata.
+
 **Project References:**
   - lookup-project-portal: Look up ESS-DIVE-related project names, acronyms, descriptions,
     and portal URLs from a shared local reference file.
@@ -64,6 +68,7 @@ import logging
 import traceback
 from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass
+from datetime import date
 from functools import lru_cache
 from pathlib import Path
 from threading import RLock
@@ -1212,6 +1217,172 @@ def sanitize_tsv_field(value) -> str:
     # Collapse multiple whitespace to a single space
     value = re.sub(r"\s+", " ", value)
     return value.strip()
+
+
+def _citation_person_name(person: Any) -> Optional[str]:
+    """Return an ESS-DIVE citation-formatted person name."""
+    if not isinstance(person, dict):
+        text = sanitize_tsv_field(person)
+        return text or None
+
+    family_name = sanitize_tsv_field(person.get("familyName"))
+    given_name = sanitize_tsv_field(person.get("givenName"))
+    if family_name and given_name:
+        initials = " ".join(
+            token[0].upper() for token in re.findall(r"[A-Za-z0-9]+", given_name)
+        )
+        return f"{family_name} {initials}".strip()
+
+    name = sanitize_tsv_field(person.get("name"))
+    if name:
+        return name
+
+    display_name = _person_display_name(person)
+    return display_name or None
+
+
+def _citation_provider_name(provider: Any) -> Optional[str]:
+    """Return the first usable project/provider organization name."""
+    for item in _as_list(provider):
+        if isinstance(item, dict):
+            name = sanitize_tsv_field(item.get("name"))
+            if name:
+                return name
+            label = ", ".join(_organization_search_strings(item))
+            if label:
+                return label
+            continue
+
+        text = sanitize_tsv_field(item)
+        if text:
+            return text
+    return None
+
+
+def _citation_publication_year(dataset: Dict[str, Any], package: Dict[str, Any]) -> str:
+    """Return the publication year for citation output."""
+    for value in (
+        dataset.get("datePublished"),
+        package.get("dateUploaded"),
+        package.get("dateModified"),
+    ):
+        text = sanitize_tsv_field(value)
+        match = re.search(r"\d{4}", text)
+        if match:
+            return match.group(0)
+    return "n.d."
+
+
+def _citation_doi(dataset: Dict[str, Any], package: Dict[str, Any]) -> Optional[str]:
+    """Return a normalized DOI from dataset or package metadata."""
+    for value in (
+        dataset.get("@id"),
+        dataset.get("doi"),
+        package.get("doi"),
+        package.get("@id"),
+    ):
+        text = sanitize_tsv_field(value)
+        if not text:
+            continue
+        doi_prefixes = (
+            "doi:",
+            "10.",
+            "https://doi.org/",
+            "http://doi.org/",
+            "doi.org/",
+        )
+        if text.startswith(doi_prefixes):
+            return _normalize_doi(text)
+    return None
+
+
+def _validate_access_date(access_date: Optional[str]) -> str:
+    """Return an ISO access date, defaulting to the server's current date."""
+    if access_date is None:
+        return date.today().isoformat()
+
+    value = sanitize_tsv_field(access_date)
+    if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", value):
+        raise ValueError("access_date must use YYYY-MM-DD format.")
+    return value
+
+
+def _ensure_repository_clause(citation: str) -> str:
+    """Add the ESS-DIVE repository clause to an existing ESS-DIVE citation."""
+    if "ESS-DIVE repository" in citation:
+        return citation.rstrip(".")
+    return re.sub(
+        r"\.\s+Dataset\.\s+(doi:10\.)",
+        r", ESS-DIVE repository. Dataset. \1",
+        citation.rstrip("."),
+        count=1,
+    )
+
+
+def generate_essdive_data_citation(
+    metadata: Dict[str, Any],
+    *,
+    access_date: Optional[str] = None,
+    access_method: str = "ESS-DIVE API over ESS-DIVE MCP",
+) -> str:
+    """Generate a consistent ESS-DIVE data citation from package metadata."""
+    if not isinstance(metadata, dict):
+        raise ValueError("metadata must be a dictionary.")
+
+    dataset = metadata.get("dataset")
+    if not isinstance(dataset, dict):
+        dataset = metadata
+
+    access_date_value = _validate_access_date(access_date)
+    access_method_value = sanitize_tsv_field(access_method)
+    if not access_method_value:
+        raise ValueError("access_method must not be blank.")
+
+    creators = [
+        name
+        for name in (
+            _citation_person_name(person)
+            for person in _as_list(dataset.get("creator"))
+        )
+        if name
+    ]
+    title = sanitize_tsv_field(dataset.get("name"))
+    doi = _citation_doi(dataset, metadata)
+
+    if creators and title and doi:
+        year = _citation_publication_year(dataset, metadata)
+        provider_name = _citation_provider_name(dataset.get("provider"))
+        if not provider_name:
+            provider_name = _citation_provider_name(dataset.get("publisher"))
+        repository_clause = "ESS-DIVE repository"
+        if provider_name:
+            repository_clause = f"{provider_name}, {repository_clause}"
+
+        return (
+            f"{' ; '.join(creators)} ({year}): {title}. "
+            f"{repository_clause}. Dataset. {doi} "
+            f"accessed via {access_method_value} on {access_date_value}"
+        )
+
+    existing_citation = sanitize_tsv_field(metadata.get("citation"))
+    if existing_citation:
+        base_citation = _ensure_repository_clause(existing_citation)
+        return (
+            f"{base_citation} accessed via {access_method_value} "
+            f"on {access_date_value}"
+        )
+
+    missing = []
+    if not creators:
+        missing.append("dataset.creator")
+    if not title:
+        missing.append("dataset.name")
+    if not doi:
+        missing.append("dataset.@id or dataset.doi")
+    raise ValueError(
+        "Dataset metadata is missing fields required for a data citation: "
+        + ", ".join(missing)
+    )
 
 
 def _norm_header_key(h: str) -> str:
@@ -2820,6 +2991,70 @@ def main():
                 exc,
                 verbose=verbose_mode,
                 context=_context_without_none({"id": id, "format": format}),
+            )
+
+    @server.tool(
+        name="generate-data-citation",
+        description="Generate a consistent ESS-DIVE data citation with MCP/API access details",
+    )
+    async def generate_data_citation(
+        id: Optional[str] = None,
+        dataset_metadata: Optional[Dict[str, Any]] = None,
+        access_date: Optional[str] = None,
+        access_method: str = "ESS-DIVE API over ESS-DIVE MCP",
+    ) -> str:
+        """
+        Generate a consistent ESS-DIVE data citation.
+
+        Provide either an ESS-DIVE dataset identifier/DOI in `id` or a package
+        metadata object such as the raw output from `get-dataset`. When `id` is
+        provided, this tool fetches current metadata from the ESS-DIVE API.
+
+        Args:
+            id: ESS-DIVE dataset identifier or DOI to fetch before formatting
+            dataset_metadata: Raw package metadata to format without fetching
+            access_date: Optional access date in YYYY-MM-DD format; defaults to today
+            access_method: Access phrase after "accessed via"; defaults to MCP/API usage
+
+        Examples:
+            generate-data-citation with id="doi:10.15485/3014404"
+            generate-data-citation with id="doi:10.15485/3014404" and access_date="2026-05-06"
+
+        Returns:
+            A formatted ESS-DIVE data citation string
+        """
+        LOGGER.debug(
+            "Tool generate-data-citation called id=%s metadata_provided=%s access_date=%s",
+            id,
+            dataset_metadata is not None,
+            access_date,
+        )
+        try:
+            if dataset_metadata is not None:
+                metadata = dataset_metadata
+            elif id:
+                metadata = await client.get_dataset(id)
+            else:
+                raise ValueError("Provide either id or dataset_metadata.")
+
+            return generate_essdive_data_citation(
+                metadata,
+                access_date=access_date,
+                access_method=access_method,
+            )
+        except Exception as exc:
+            return _tool_error_response(
+                "generate-data-citation",
+                exc,
+                verbose=verbose_mode,
+                context=_context_without_none(
+                    {
+                        "id": id,
+                        "dataset_metadata_provided": dataset_metadata is not None,
+                        "access_date": access_date,
+                        "access_method": access_method,
+                    }
+                ),
             )
 
     @server.tool(

--- a/src/essdive_mcp/main.py
+++ b/src/essdive_mcp/main.py
@@ -35,8 +35,8 @@ MCP Tools Available:
     description mappings for dataset files.
 
 **Export Helpers:**
-  - generate-data-citation: Generate a consistent ESS-DIVE data citation with
-    repository and MCP/API access details for a dataset ID or provided metadata.
+  - generate-data-citation: Generate a consistent data citation with repository
+    and access details for ESS-DIVE metadata, with Crossref fallback for other DOIs.
 
 **Project References:**
   - lookup-project-portal: Look up ESS-DIVE-related project names, acronyms, descriptions,
@@ -92,6 +92,12 @@ PAGINATION_STATE_CLEANUP_INTERVAL_SECONDS = 60.0
 DEFAULT_HTTP_HOST = "127.0.0.1"
 DEFAULT_HTTP_PORT = 8000
 DEFAULT_HTTP_PATH = "/mcp"
+DEFAULT_ESSDIVE_ACCESS_METHOD = "ESS-DIVE API over ESS-DIVE MCP"
+DEFAULT_CROSSREF_ACCESS_METHOD = "Crossref API over ESS-DIVE MCP"
+CROSSREF_WORKS_URL = "https://api.crossref.org/works"
+CROSSREF_USER_AGENT = (
+    "essdive-mcp/0.3.1 (https://github.com/ess-dive/essdive-mcp)"
+)
 T = TypeVar("T")
 PROJECT_PORTALS_PATH = (
     Path(__file__).resolve().parents[2]
@@ -1219,14 +1225,31 @@ def sanitize_tsv_field(value) -> str:
     return value.strip()
 
 
+def _looks_like_doi_identifier(identifier: Optional[str]) -> bool:
+    """Return True when an identifier has a recognizable DOI shape."""
+    text = sanitize_tsv_field(identifier)
+    if not text:
+        return False
+    for prefix in ("https://doi.org/", "http://doi.org/", "doi.org/", "doi:"):
+        if text.lower().startswith(prefix):
+            text = text[len(prefix):]
+            break
+    return bool(re.fullmatch(r"10\.\S+/.+", text))
+
+
+def _is_essdive_doi(identifier: str) -> bool:
+    """Return True for normalized ESS-DIVE DOI identifiers."""
+    return _normalize_doi(identifier).startswith("doi:10.15485/")
+
+
 def _citation_person_name(person: Any) -> Optional[str]:
     """Return an ESS-DIVE citation-formatted person name."""
     if not isinstance(person, dict):
         text = sanitize_tsv_field(person)
         return text or None
 
-    family_name = sanitize_tsv_field(person.get("familyName"))
-    given_name = sanitize_tsv_field(person.get("givenName"))
+    family_name = sanitize_tsv_field(person.get("familyName") or person.get("family"))
+    given_name = sanitize_tsv_field(person.get("givenName") or person.get("given"))
     if family_name and given_name:
         initials = " ".join(
             token[0].upper() for token in re.findall(r"[A-Za-z0-9]+", given_name)
@@ -1296,6 +1319,112 @@ def _citation_doi(dataset: Dict[str, Any], package: Dict[str, Any]) -> Optional[
     return None
 
 
+def _first_text(value: Any) -> Optional[str]:
+    """Return the first nonblank text value from a string or list."""
+    for item in _as_list(value):
+        text = sanitize_tsv_field(item)
+        if text:
+            return text
+    return None
+
+
+def _crossref_publication_year(message: Dict[str, Any]) -> str:
+    """Return the best publication year available from Crossref metadata."""
+    for key in ("issued", "published-print", "published-online", "created"):
+        date_parts = message.get(key, {}).get("date-parts")
+        if not isinstance(date_parts, list) or not date_parts:
+            continue
+        first_part = date_parts[0]
+        if isinstance(first_part, list) and first_part:
+            year = sanitize_tsv_field(first_part[0])
+            if re.fullmatch(r"\d{4}", year):
+                return year
+    return "n.d."
+
+
+def _crossref_type_label(work_type: Any) -> str:
+    """Return a human-readable Crossref work type."""
+    text = sanitize_tsv_field(work_type)
+    if not text:
+        return "Reference"
+    return text.replace("-", " ").capitalize()
+
+
+def _fetch_crossref_work(doi: str) -> Dict[str, Any]:
+    """Fetch a Crossref work metadata message for a DOI."""
+    normalized_doi = _normalize_doi(doi)
+    bare_doi = normalized_doi.removeprefix("doi:")
+    try:
+        response = requests.get(
+            f"{CROSSREF_WORKS_URL}/{quote(bare_doi, safe='')}",
+            headers={"User-Agent": CROSSREF_USER_AGENT},
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+    except requests.RequestException as exc:
+        raise ValueError(
+            f"Crossref API request failed: {exc.__class__.__name__}"
+        ) from exc
+    if response.status_code != 200:
+        raise ValueError(f"Crossref API returned HTTP {response.status_code}")
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise ValueError("Crossref API returned invalid JSON") from exc
+
+    message = payload.get("message")
+    if not isinstance(message, dict):
+        raise ValueError("Crossref response did not contain work metadata")
+    return message
+
+
+def generate_crossref_data_citation(
+    message: Dict[str, Any],
+    *,
+    doi: Optional[str] = None,
+    access_date: Optional[str] = None,
+    access_method: str = DEFAULT_CROSSREF_ACCESS_METHOD,
+) -> str:
+    """Generate a citation-shaped reference from Crossref work metadata."""
+    if not isinstance(message, dict):
+        raise ValueError("Crossref metadata must be a dictionary.")
+
+    access_date_value = _validate_access_date(access_date)
+    access_method_value = sanitize_tsv_field(access_method)
+    if not access_method_value:
+        raise ValueError("access_method must not be blank.")
+
+    authors = [
+        name
+        for name in (
+            _citation_person_name(person)
+            for person in _as_list(message.get("author"))
+        )
+        if name
+    ]
+    author_text = " ; ".join(authors) if authors else "Unknown author"
+    year = _crossref_publication_year(message)
+    title = _first_text(message.get("title"))
+    if not title:
+        raise ValueError("Crossref response did not contain a title.")
+
+    source = (
+        _first_text(message.get("container-title"))
+        or sanitize_tsv_field(message.get("publisher"))
+        or "Crossref"
+    )
+    work_type = _crossref_type_label(message.get("type"))
+    raw_doi = sanitize_tsv_field(message.get("DOI")) or sanitize_tsv_field(doi)
+    if not _looks_like_doi_identifier(raw_doi):
+        raise ValueError("Crossref response did not contain a DOI.")
+    citation_doi = _normalize_doi(raw_doi)
+
+    return (
+        f"{author_text} ({year}): {title}. {source}. {work_type}. "
+        f"{citation_doi} accessed via {access_method_value} on {access_date_value}"
+    )
+
+
 def _validate_access_date(access_date: Optional[str]) -> str:
     """Return an ISO access date, defaulting to the server's current date."""
     if access_date is None:
@@ -1323,7 +1452,7 @@ def generate_essdive_data_citation(
     metadata: Dict[str, Any],
     *,
     access_date: Optional[str] = None,
-    access_method: str = "ESS-DIVE API over ESS-DIVE MCP",
+    access_method: str = DEFAULT_ESSDIVE_ACCESS_METHOD,
 ) -> str:
     """Generate a consistent ESS-DIVE data citation from package metadata."""
     if not isinstance(metadata, dict):
@@ -1383,6 +1512,96 @@ def generate_essdive_data_citation(
         "Dataset metadata is missing fields required for a data citation: "
         + ", ".join(missing)
     )
+
+
+async def generate_data_citation_for_identifier(
+    client: "ESSDiveClient",
+    identifier: str,
+    *,
+    access_date: Optional[str] = None,
+    access_method: str = DEFAULT_ESSDIVE_ACCESS_METHOD,
+) -> tuple[str, List[str]]:
+    """Generate a citation from an identifier with Crossref fallback for DOIs."""
+    warnings: List[str] = []
+    normalized_doi = (
+        _normalize_doi(identifier) if _looks_like_doi_identifier(identifier) else None
+    )
+
+    if normalized_doi and not _is_essdive_doi(normalized_doi):
+        crossref_message = await asyncio.to_thread(
+            _fetch_crossref_work, normalized_doi
+        )
+        warnings.append(
+            f"{normalized_doi} is not an ESS-DIVE DOI; citation was generated "
+            "from Crossref metadata and may not describe an ESS-DIVE dataset."
+        )
+        crossref_access_method = (
+            DEFAULT_CROSSREF_ACCESS_METHOD
+            if access_method == DEFAULT_ESSDIVE_ACCESS_METHOD
+            else access_method
+        )
+        return (
+            generate_crossref_data_citation(
+                crossref_message,
+                doi=normalized_doi,
+                access_date=access_date,
+                access_method=crossref_access_method,
+            ),
+            warnings,
+        )
+
+    try:
+        metadata = await client.get_dataset(identifier)
+        return (
+            generate_essdive_data_citation(
+                metadata,
+                access_date=access_date,
+                access_method=access_method,
+            ),
+            warnings,
+        )
+    except Exception as essdive_exc:
+        if not normalized_doi:
+            raise
+
+        try:
+            crossref_message = await asyncio.to_thread(
+                _fetch_crossref_work, normalized_doi
+            )
+        except Exception as crossref_exc:
+            raise ValueError(
+                f"Failed to retrieve citation metadata for {normalized_doi} "
+                "from ESS-DIVE or Crossref. "
+                f"ESS-DIVE error: {essdive_exc}. Crossref error: {crossref_exc}"
+            ) from crossref_exc
+
+        warnings.append(
+            f"{normalized_doi} could not be retrieved from ESS-DIVE; citation "
+            "was generated from Crossref metadata and may not describe an "
+            "ESS-DIVE dataset."
+        )
+        crossref_access_method = (
+            DEFAULT_CROSSREF_ACCESS_METHOD
+            if access_method == DEFAULT_ESSDIVE_ACCESS_METHOD
+            else access_method
+        )
+        return (
+            generate_crossref_data_citation(
+                crossref_message,
+                doi=normalized_doi,
+                access_date=access_date,
+                access_method=crossref_access_method,
+            ),
+            warnings,
+        )
+
+
+def _format_citation_output(citation: str, warnings: List[str]) -> str:
+    """Render citation output with agent-visible warning lines."""
+    if not warnings:
+        return citation
+    warning_text = "\n".join(f"WARNING: {warning}" for warning in warnings)
+    return f"{warning_text}\n\n{citation}"
 
 
 def _norm_header_key(h: str) -> str:
@@ -2320,17 +2539,20 @@ def _normalize_doi(identifier: str) -> str:
         'doi:10.15485/2453885'
     """
     identifier = identifier.strip()
+    lowered = identifier.lower()
 
     # Remove common DOI URL prefixes
-    if identifier.startswith("https://doi.org/"):
-        identifier = identifier.replace("https://doi.org/", "")
-    elif identifier.startswith("http://doi.org/"):
-        identifier = identifier.replace("http://doi.org/", "")
-    elif identifier.startswith("doi.org/"):
-        identifier = identifier.replace("doi.org/", "")
+    if lowered.startswith("https://doi.org/"):
+        identifier = identifier[len("https://doi.org/"):]
+    elif lowered.startswith("http://doi.org/"):
+        identifier = identifier[len("http://doi.org/"):]
+    elif lowered.startswith("doi.org/"):
+        identifier = identifier[len("doi.org/"):]
 
     # Add doi: prefix if not present
-    if not identifier.startswith("doi:"):
+    if identifier.lower().startswith("doi:"):
+        identifier = f"doi:{identifier[4:]}"
+    else:
         identifier = f"doi:{identifier}"
 
     return identifier
@@ -2995,20 +3217,21 @@ def main():
 
     @server.tool(
         name="generate-data-citation",
-        description="Generate a consistent ESS-DIVE data citation with MCP/API access details",
+        description="Generate a consistent data citation with MCP/API access details",
     )
     async def generate_data_citation(
         id: Optional[str] = None,
         dataset_metadata: Optional[Dict[str, Any]] = None,
         access_date: Optional[str] = None,
-        access_method: str = "ESS-DIVE API over ESS-DIVE MCP",
+        access_method: str = DEFAULT_ESSDIVE_ACCESS_METHOD,
     ) -> str:
         """
-        Generate a consistent ESS-DIVE data citation.
+        Generate a consistent data citation.
 
         Provide either an ESS-DIVE dataset identifier/DOI in `id` or a package
         metadata object such as the raw output from `get-dataset`. When `id` is
-        provided, this tool fetches current metadata from the ESS-DIVE API.
+        provided, this tool fetches current metadata from the ESS-DIVE API. If
+        `id` is a DOI outside ESS-DIVE, the tool warns and tries Crossref.
 
         Args:
             id: ESS-DIVE dataset identifier or DOI to fetch before formatting
@@ -3031,17 +3254,22 @@ def main():
         )
         try:
             if dataset_metadata is not None:
-                metadata = dataset_metadata
+                citation = generate_essdive_data_citation(
+                    dataset_metadata,
+                    access_date=access_date,
+                    access_method=access_method,
+                )
+                return _format_citation_output(citation, [])
             elif id:
-                metadata = await client.get_dataset(id)
+                citation, warnings = await generate_data_citation_for_identifier(
+                    client,
+                    id,
+                    access_date=access_date,
+                    access_method=access_method,
+                )
+                return _format_citation_output(citation, warnings)
             else:
                 raise ValueError("Provide either id or dataset_metadata.")
-
-            return generate_essdive_data_citation(
-                metadata,
-                access_date=access_date,
-                access_method=access_method,
-            )
         except Exception as exc:
             return _tool_error_response(
                 "generate-data-citation",

--- a/src/essdive_mcp/main.py
+++ b/src/essdive_mcp/main.py
@@ -1242,6 +1242,13 @@ def _is_essdive_doi(identifier: str) -> bool:
     return _normalize_doi(identifier).startswith("doi:10.15485/")
 
 
+def _crossref_access_method(access_method: str) -> str:
+    """Use a Crossref-specific access phrase unless the caller customized it."""
+    if access_method == DEFAULT_ESSDIVE_ACCESS_METHOD:
+        return DEFAULT_CROSSREF_ACCESS_METHOD
+    return access_method
+
+
 def _citation_person_name(person: Any) -> Optional[str]:
     """Return an ESS-DIVE citation-formatted person name."""
     if not isinstance(person, dict):
@@ -1301,8 +1308,10 @@ def _citation_doi(dataset: Dict[str, Any], package: Dict[str, Any]) -> Optional[
     for value in (
         dataset.get("@id"),
         dataset.get("doi"),
+        dataset.get("DOI"),
         package.get("doi"),
         package.get("@id"),
+        package.get("DOI"),
     ):
         text = sanitize_tsv_field(value)
         if not text:
@@ -1514,6 +1523,57 @@ def generate_essdive_data_citation(
     )
 
 
+def _metadata_dataset(metadata: Dict[str, Any]) -> Dict[str, Any]:
+    """Return nested dataset metadata when present, otherwise the metadata itself."""
+    dataset = metadata.get("dataset")
+    if isinstance(dataset, dict):
+        return dataset
+    return metadata
+
+
+async def generate_data_citation_for_metadata(
+    metadata: Dict[str, Any],
+    *,
+    access_date: Optional[str] = None,
+    access_method: str = DEFAULT_ESSDIVE_ACCESS_METHOD,
+) -> tuple[str, List[str]]:
+    """Generate a citation from provided metadata while preserving source clarity."""
+    if not isinstance(metadata, dict):
+        raise ValueError("metadata must be a dictionary.")
+
+    dataset = _metadata_dataset(metadata)
+    doi = _citation_doi(dataset, metadata)
+
+    if doi and not _is_essdive_doi(doi):
+        warnings = [
+            f"{doi} is not an ESS-DIVE DOI; provided metadata was not treated "
+            "as ESS-DIVE metadata."
+        ]
+        if metadata.get("DOI") or dataset.get("DOI"):
+            crossref_message = metadata
+        else:
+            crossref_message = await asyncio.to_thread(_fetch_crossref_work, doi)
+
+        return (
+            generate_crossref_data_citation(
+                crossref_message,
+                doi=doi,
+                access_date=access_date,
+                access_method=_crossref_access_method(access_method),
+            ),
+            warnings,
+        )
+
+    return (
+        generate_essdive_data_citation(
+            metadata,
+            access_date=access_date,
+            access_method=access_method,
+        ),
+        [],
+    )
+
+
 async def generate_data_citation_for_identifier(
     client: "ESSDiveClient",
     identifier: str,
@@ -1535,17 +1595,12 @@ async def generate_data_citation_for_identifier(
             f"{normalized_doi} is not an ESS-DIVE DOI; citation was generated "
             "from Crossref metadata and may not describe an ESS-DIVE dataset."
         )
-        crossref_access_method = (
-            DEFAULT_CROSSREF_ACCESS_METHOD
-            if access_method == DEFAULT_ESSDIVE_ACCESS_METHOD
-            else access_method
-        )
         return (
             generate_crossref_data_citation(
                 crossref_message,
                 doi=normalized_doi,
                 access_date=access_date,
-                access_method=crossref_access_method,
+                access_method=_crossref_access_method(access_method),
             ),
             warnings,
         )
@@ -1580,17 +1635,12 @@ async def generate_data_citation_for_identifier(
             "was generated from Crossref metadata and may not describe an "
             "ESS-DIVE dataset."
         )
-        crossref_access_method = (
-            DEFAULT_CROSSREF_ACCESS_METHOD
-            if access_method == DEFAULT_ESSDIVE_ACCESS_METHOD
-            else access_method
-        )
         return (
             generate_crossref_data_citation(
                 crossref_message,
                 doi=normalized_doi,
                 access_date=access_date,
-                access_method=crossref_access_method,
+                access_method=_crossref_access_method(access_method),
             ),
             warnings,
         )
@@ -3254,12 +3304,12 @@ def main():
         )
         try:
             if dataset_metadata is not None:
-                citation = generate_essdive_data_citation(
+                citation, warnings = await generate_data_citation_for_metadata(
                     dataset_metadata,
                     access_date=access_date,
                     access_method=access_method,
                 )
-                return _format_citation_output(citation, [])
+                return _format_citation_output(citation, warnings)
             elif id:
                 citation, warnings = await generate_data_citation_for_identifier(
                     client,

--- a/tests/unit/test_api_unit.py
+++ b/tests/unit/test_api_unit.py
@@ -25,6 +25,7 @@ from essdive_mcp.main import (
     _build_arg_parser,
     _resolve_runtime_config,
     PaginationStateStore,
+    generate_essdive_data_citation,
 )
 import pytest
 import os
@@ -1793,6 +1794,89 @@ class TestFormatResults:
         ) in formatted
         assert "Newer Version URL" in formatted
         assert "Older Version URL" in formatted
+
+
+class TestDataCitation:
+    """Tests for ESS-DIVE data citation formatting."""
+
+    def test_generate_essdive_data_citation_from_package_metadata(self):
+        """Structured metadata should produce the expected ESS-DIVE data citation."""
+        metadata = {
+            "id": "ess-dive-c867baa5f602eed-20260506T011608834",
+            "dataset": {
+                "@id": "doi:10.15485/3014404",
+                "name": "CHESS 2025: Field-collected vegetation attributes and site photos",
+                "datePublished": "2026-03-10",
+                "creator": [
+                    {"givenName": "Ian", "familyName": "Breckheimer"},
+                    {"givenName": "Erin", "familyName": "Carroll"},
+                    {"givenName": "K. Dana", "familyName": "Chadwick"},
+                    {"givenName": "Dylan", "familyName": "O'Ryan"},
+                    {"givenName": "H. Marshall", "familyName": "Worsham"},
+                ],
+                "provider": {"name": "Watershed Function SFA"},
+            },
+        }
+
+        citation = generate_essdive_data_citation(
+            metadata, access_date="2026-05-06")
+
+        assert citation == (
+            "Breckheimer I ; Carroll E ; Chadwick K D ; O'Ryan D ; "
+            "Worsham H M (2026): CHESS 2025: Field-collected vegetation "
+            "attributes and site photos. Watershed Function SFA, ESS-DIVE "
+            "repository. Dataset. doi:10.15485/3014404 accessed via "
+            "ESS-DIVE API over ESS-DIVE MCP on 2026-05-06"
+        )
+
+    def test_generate_essdive_data_citation_accepts_dataset_only_metadata(self):
+        """Callers may pass the nested dataset object directly."""
+        citation = generate_essdive_data_citation(
+            {
+                "@id": "https://doi.org/10.15485/example",
+                "name": "Example dataset",
+                "datePublished": "2025",
+                "creator": {"givenName": "Ada", "familyName": "Lovelace"},
+            },
+            access_date="2026-05-06",
+            access_method="unit test",
+        )
+
+        assert citation == (
+            "Lovelace A (2025): Example dataset. ESS-DIVE repository. "
+            "Dataset. doi:10.15485/example accessed via unit test on 2026-05-06"
+        )
+
+    def test_generate_essdive_data_citation_falls_back_to_existing_citation(self):
+        """Existing ESS-DIVE citations should be augmented with repository/access text."""
+        citation = generate_essdive_data_citation(
+            {
+                "citation": (
+                    "Breckheimer I; Carroll E (2026): Example dataset. "
+                    "Watershed Function SFA. Dataset. doi:10.15485/3014404"
+                )
+            },
+            access_date="2026-05-06",
+        )
+
+        assert citation == (
+            "Breckheimer I; Carroll E (2026): Example dataset. "
+            "Watershed Function SFA, ESS-DIVE repository. Dataset. "
+            "doi:10.15485/3014404 accessed via ESS-DIVE API over ESS-DIVE MCP "
+            "on 2026-05-06"
+        )
+
+    def test_generate_essdive_data_citation_rejects_bad_access_date(self):
+        """Access dates should use ISO date format for consistent exports."""
+        with pytest.raises(ValueError, match="YYYY-MM-DD"):
+            generate_essdive_data_citation(
+                {
+                    "@id": "doi:10.15485/example",
+                    "name": "Example dataset",
+                    "creator": {"givenName": "Ada", "familyName": "Lovelace"},
+                },
+                access_date="05/06/2026",
+            )
 
 
 class TestNormalizeDoi:

--- a/tests/unit/test_api_unit.py
+++ b/tests/unit/test_api_unit.py
@@ -26,6 +26,11 @@ from essdive_mcp.main import (
     _resolve_runtime_config,
     PaginationStateStore,
     generate_essdive_data_citation,
+    generate_crossref_data_citation,
+    generate_data_citation_for_identifier,
+    _format_citation_output,
+    _fetch_crossref_work,
+    _looks_like_doi_identifier,
 )
 import pytest
 import os
@@ -1878,6 +1883,169 @@ class TestDataCitation:
                 access_date="05/06/2026",
             )
 
+    @pytest.mark.parametrize(
+        ("identifier", "expected"),
+        [
+            ("doi:10.1038/nature12373", True),
+            ("DOI:10.1038/nature12373", True),
+            ("10.1038/nature12373", True),
+            ("https://doi.org/10.1038/nature12373", True),
+            ("ess-dive-abc123", False),
+            ("doi:not-a-real-doi", False),
+        ],
+    )
+    def test_looks_like_doi_identifier(self, identifier, expected):
+        """DOI fallback should only run for recognizable DOI-shaped values."""
+        assert _looks_like_doi_identifier(identifier) is expected
+
+    def test_generate_crossref_data_citation(self):
+        """Crossref metadata should format into a citation-like reference."""
+        citation = generate_crossref_data_citation(
+            {
+                "DOI": "10.1038/nature12373",
+                "type": "journal-article",
+                "title": ["Nanometre-scale thermometry in a living cell"],
+                "container-title": ["Nature"],
+                "issued": {"date-parts": [[2013, 8]]},
+                "author": [
+                    {"given": "G.", "family": "Kucsko"},
+                    {"given": "P. C.", "family": "Maurer"},
+                ],
+            },
+            access_date="2026-05-06",
+        )
+
+        assert citation == (
+            "Kucsko G ; Maurer P C (2013): Nanometre-scale thermometry "
+            "in a living cell. Nature. Journal article. doi:10.1038/nature12373 "
+            "accessed via Crossref API over ESS-DIVE MCP on 2026-05-06"
+        )
+
+    def test_format_citation_output_surfaces_warnings(self):
+        """Warnings should be visible before citation text for agents."""
+        output = _format_citation_output(
+            "Example citation",
+            ["doi:10.1038/example is not an ESS-DIVE DOI."],
+        )
+
+        assert output == (
+            "WARNING: doi:10.1038/example is not an ESS-DIVE DOI.\n\n"
+            "Example citation"
+        )
+
+    def test_fetch_crossref_work_success(self):
+        """Crossref fetch should return the work metadata message."""
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {"message": {"DOI": "10.1038/example"}}
+
+        with patch("essdive_mcp.main.requests.get", return_value=response) as get:
+            result = _fetch_crossref_work("doi:10.1038/example")
+
+        assert result == {"DOI": "10.1038/example"}
+        assert get.call_args.args[0].endswith("/10.1038%2Fexample")
+
+    def test_fetch_crossref_work_http_error(self):
+        """Crossref HTTP misses should raise a clear error."""
+        response = Mock()
+        response.status_code = 404
+
+        with patch("essdive_mcp.main.requests.get", return_value=response):
+            with pytest.raises(ValueError, match="HTTP 404"):
+                _fetch_crossref_work("doi:10.1038/missing")
+
+    def test_fetch_crossref_work_invalid_json(self):
+        """Invalid Crossref JSON should raise a clear error."""
+        response = Mock()
+        response.status_code = 200
+        response.json.side_effect = ValueError("bad json")
+
+        with patch("essdive_mcp.main.requests.get", return_value=response):
+            with pytest.raises(ValueError, match="invalid JSON"):
+                _fetch_crossref_work("doi:10.1038/example")
+
+    def test_fetch_crossref_work_request_error(self):
+        """Crossref request failures should raise a clear error."""
+        with patch(
+            "essdive_mcp.main.requests.get",
+            side_effect=requests.RequestException("network"),
+        ):
+            with pytest.raises(ValueError, match="request failed"):
+                _fetch_crossref_work("doi:10.1038/example")
+
+    @pytest.mark.asyncio
+    async def test_generate_data_citation_for_non_essdive_doi_warns(self):
+        """Non-ESS-DIVE DOIs should use Crossref and warn the caller."""
+        client = Mock()
+        client.get_dataset = AsyncMock()
+        crossref_message = {
+            "DOI": "10.1038/nature12373",
+            "type": "journal-article",
+            "title": ["Nanometre-scale thermometry in a living cell"],
+            "container-title": ["Nature"],
+            "issued": {"date-parts": [[2013]]},
+            "author": [{"given": "G.", "family": "Kucsko"}],
+        }
+
+        with patch(
+            "essdive_mcp.main._fetch_crossref_work",
+            return_value=crossref_message,
+        ) as fetch_crossref:
+            citation, warnings = await generate_data_citation_for_identifier(
+                client,
+                "doi:10.1038/nature12373",
+                access_date="2026-05-06",
+            )
+
+        client.get_dataset.assert_not_called()
+        fetch_crossref.assert_called_once_with("doi:10.1038/nature12373")
+        assert warnings == [
+            "doi:10.1038/nature12373 is not an ESS-DIVE DOI; citation was "
+            "generated from Crossref metadata and may not describe an "
+            "ESS-DIVE dataset."
+        ]
+        assert citation.endswith(
+            "doi:10.1038/nature12373 accessed via Crossref API over "
+            "ESS-DIVE MCP on 2026-05-06"
+        )
+
+    @pytest.mark.asyncio
+    async def test_generate_data_citation_for_missing_essdive_doi_tries_crossref(self):
+        """DOI-shaped ESS-DIVE misses should try Crossref before failing."""
+        client = Mock()
+        client.get_dataset = AsyncMock(side_effect=ValueError("not found"))
+        crossref_message = {
+            "DOI": "10.15485/does-exist-elsewhere",
+            "type": "dataset",
+            "title": ["Archived dataset"],
+            "publisher": "Example Repository",
+            "issued": {"date-parts": [[2024]]},
+            "author": [{"given": "Ada", "family": "Lovelace"}],
+        }
+
+        with patch(
+            "essdive_mcp.main._fetch_crossref_work",
+            return_value=crossref_message,
+        ) as fetch_crossref:
+            citation, warnings = await generate_data_citation_for_identifier(
+                client,
+                "doi:10.15485/does-exist-elsewhere",
+                access_date="2026-05-06",
+            )
+
+        client.get_dataset.assert_awaited_once()
+        fetch_crossref.assert_called_once_with("doi:10.15485/does-exist-elsewhere")
+        assert warnings == [
+            "doi:10.15485/does-exist-elsewhere could not be retrieved from "
+            "ESS-DIVE; citation was generated from Crossref metadata and may "
+            "not describe an ESS-DIVE dataset."
+        ]
+        assert citation == (
+            "Lovelace A (2024): Archived dataset. Example Repository. Dataset. "
+            "doi:10.15485/does-exist-elsewhere accessed via Crossref API over "
+            "ESS-DIVE MCP on 2026-05-06"
+        )
+
 
 class TestNormalizeDoi:
     """Tests for the _normalize_doi helper function."""
@@ -1885,6 +2053,11 @@ class TestNormalizeDoi:
     def test_normalize_doi_with_doi_prefix(self):
         """Test normalizing a DOI that already has the doi: prefix."""
         result = _normalize_doi("doi:10.1234/example")
+        assert result == "doi:10.1234/example"
+
+    def test_normalize_doi_with_uppercase_doi_prefix(self):
+        """Test normalizing a DOI with uppercase DOI prefix."""
+        result = _normalize_doi("DOI:10.1234/example")
         assert result == "doi:10.1234/example"
 
     def test_normalize_doi_without_prefix(self):

--- a/tests/unit/test_api_unit.py
+++ b/tests/unit/test_api_unit.py
@@ -28,6 +28,7 @@ from essdive_mcp.main import (
     generate_essdive_data_citation,
     generate_crossref_data_citation,
     generate_data_citation_for_identifier,
+    generate_data_citation_for_metadata,
     _format_citation_output,
     _fetch_crossref_work,
     _looks_like_doi_identifier,
@@ -2008,6 +2009,88 @@ class TestDataCitation:
             "doi:10.1038/nature12373 accessed via Crossref API over "
             "ESS-DIVE MCP on 2026-05-06"
         )
+
+    @pytest.mark.asyncio
+    async def test_generate_data_citation_for_metadata_keeps_essdive_source(self):
+        """ESS-DIVE metadata should keep ESS-DIVE repository citation formatting."""
+        citation, warnings = await generate_data_citation_for_metadata(
+            {
+                "dataset": {
+                    "@id": "doi:10.15485/example",
+                    "name": "Example dataset",
+                    "datePublished": "2025",
+                    "creator": {"givenName": "Ada", "familyName": "Lovelace"},
+                }
+            },
+            access_date="2026-05-06",
+        )
+
+        assert warnings == []
+        assert citation == (
+            "Lovelace A (2025): Example dataset. ESS-DIVE repository. "
+            "Dataset. doi:10.15485/example accessed via ESS-DIVE API over "
+            "ESS-DIVE MCP on 2026-05-06"
+        )
+
+    @pytest.mark.asyncio
+    async def test_generate_data_citation_for_metadata_warns_for_non_essdive_doi(self):
+        """Provided non-ESS-DIVE metadata should not be labeled as ESS-DIVE."""
+        crossref_message = {
+            "DOI": "10.1038/nature12373",
+            "type": "journal-article",
+            "title": ["Nanometre-scale thermometry in a living cell"],
+            "container-title": ["Nature"],
+            "issued": {"date-parts": [[2013]]},
+            "author": [{"given": "G.", "family": "Kucsko"}],
+        }
+
+        with patch(
+            "essdive_mcp.main._fetch_crossref_work",
+            return_value=crossref_message,
+        ) as fetch_crossref:
+            citation, warnings = await generate_data_citation_for_metadata(
+                {
+                    "@id": "doi:10.1038/nature12373",
+                    "name": "Nanometre-scale thermometry in a living cell",
+                    "datePublished": "2013",
+                    "creator": {"givenName": "G.", "familyName": "Kucsko"},
+                },
+                access_date="2026-05-06",
+            )
+
+        fetch_crossref.assert_called_once_with("doi:10.1038/nature12373")
+        assert warnings == [
+            "doi:10.1038/nature12373 is not an ESS-DIVE DOI; provided "
+            "metadata was not treated as ESS-DIVE metadata."
+        ]
+        assert "ESS-DIVE repository" not in citation
+        assert citation == (
+            "Kucsko G (2013): Nanometre-scale thermometry in a living cell. "
+            "Nature. Journal article. doi:10.1038/nature12373 accessed via "
+            "Crossref API over ESS-DIVE MCP on 2026-05-06"
+        )
+
+    @pytest.mark.asyncio
+    async def test_generate_data_citation_for_crossref_metadata_uses_provided_message(self):
+        """Crossref-shaped metadata should warn and avoid an extra fetch."""
+        citation, warnings = await generate_data_citation_for_metadata(
+            {
+                "DOI": "10.1038/nature12373",
+                "type": "journal-article",
+                "title": ["Nanometre-scale thermometry in a living cell"],
+                "container-title": ["Nature"],
+                "issued": {"date-parts": [[2013]]},
+                "author": [{"given": "G.", "family": "Kucsko"}],
+            },
+            access_date="2026-05-06",
+        )
+
+        assert warnings == [
+            "doi:10.1038/nature12373 is not an ESS-DIVE DOI; provided "
+            "metadata was not treated as ESS-DIVE metadata."
+        ]
+        assert citation.startswith("Kucsko G (2013):")
+        assert "Crossref API over ESS-DIVE MCP" in citation
 
     @pytest.mark.asyncio
     async def test_generate_data_citation_for_missing_essdive_doi_tries_crossref(self):


### PR DESCRIPTION
## Summary
- add `generate-data-citation` MCP tool for dataset IDs or provided package metadata
- format ESS-DIVE citations with creator initials, publication year, provider plus ESS-DIVE repository, DOI, and MCP/API access details
- add warning-backed Crossref fallback for non-ESS-DIVE DOIs, while invalid or unknown DOIs return errors rather than fabricated citations
- source-check provided `dataset_metadata` so non-ESS-DIVE metadata is never silently labeled as an ESS-DIVE repository citation
- add dedicated `essdive-data-citations` Skill and update existing dataset, identifier, and ESS-DeepDive Skills to reference citation generation and preserve warnings
- update Skill docs, Codex install scripts, and Claude marketplace metadata
- document the new tool and add unit coverage for ESS-DIVE metadata, Crossref metadata, warning output, DOI normalization, Crossref error handling, metadata-source checks, and fallback paths

Closes #31.

## Validation
- `uv run pytest tests/unit/test_api_unit.py -q`
- `uv run pytest -q`
- `git diff --check`
- `bash -n scripts/install_codex_skills.sh scripts/uninstall_codex_skills.sh`
- `python3 -m json.tool .claude-plugin/marketplace.json >/dev/null`
- install/uninstall scripts exercised with a temporary `CODEX_HOME`
- live citation checks for `doi:10.15485/2513897`, `doi:10.15485/2589093`, `doi:10.15485/3018020`, `doi:10.1038/nature12373`, invalid `doi:10.9999/not-a-real-doi-for-essdive-mcp`, and non-ESS-DIVE `dataset_metadata`
- short streamable HTTP server startup check with `timeout 5 uv run essdive-mcp --transport streamable-http --host 127.0.0.1 --port 8123`