### PR TITLE
Surface canonical providerName from dataset search results (closes #40)

### DIFF
--- a/.agents/skills/essdive-data-citations/SKILL.md
+++ b/.agents/skills/essdive-data-citations/SKILL.md
@@ -168,7 +168,9 @@ If the MCP server is unavailable, fetch search/list or dataset metadata from the
 ESS-DIVE API. Prefer the API-provided top-level `citation` field from
 `/packages` or `/packages/{identifier}` when present. Only construct the same
 citation shape from `dataset.creator`, `dataset.datePublished`, `dataset.name`,
-`dataset.provider.name`, and `dataset.@id` if the response has no `citation`:
+`dataset.provider.name` (or the `dataset.providerName` string returned by
+`/packages` search results), and `dataset.@id` if the response has no
+`citation`:
 
 ```bash
 curl -sG "https://api.ess-dive.lbl.gov/packages/doi%3A10.15485%2F3014404" \

--- a/.agents/skills/essdive-datasets/SKILL.md
+++ b/.agents/skills/essdive-datasets/SKILL.md
@@ -81,6 +81,18 @@ canonical ESS-DIVE provider name before calling `search-datasets`. Examples:
 reference file to resolve acronyms, aliases, and spacing variants whenever
 there is ambiguity.
 
+Every search result now carries the canonical provider name as
+`dataset.providerName`, and `search-datasets` surfaces it on a `Provider:` line
+in both `summary` and `detailed` output. Use it to confirm which provider each
+result belongs to — you no longer need a per-dataset `get-dataset` lookup or to
+parse the citation string just to learn the provider.
+
+Because `provider_name` matching is tokenized, a partial or inexact value can
+return datasets from more than one provider (for example, `provider_name=watershed`
+also matches `River Corridor and Watershed Biogeochemistry SFA`). When the user
+wants datasets from a single provider, prefer the canonical name, then verify or
+filter results by their `dataset.providerName` and keep only the exact matches.
+
 Filter by temporal coverage:
 
 ```
@@ -326,6 +338,7 @@ coords-to-map-links with bbox=[38.9187, -106.9532, 38.9263, -106.9451]
 - Point search requires `lat`, `lon`, and `radius` together. Do not combine point search with `bbox`.
 - Native ESS-DIVE `/packages` filters include `query`/`text`, `creator`, `provider_name`, `date_published`, `begin_date`, `end_date`, `keywords`, `sort`, `bbox`, and `lat`/`lon`/`radius`.
 - For `provider_name`, prefer the canonical ESS-DIVE provider/project name rather than a shorthand or spacing variant. Normalize likely variants first, then pass the canonical name to `search-datasets`.
+- Search results include the canonical provider as `dataset.providerName` (shown on the `Provider:` line). Because matching is tokenized, an inexact `provider_name` can return multiple distinct providers; verify or filter results by `dataset.providerName` instead of issuing a `get-dataset` request per result.
 - Additional filters such as `creator_affiliation`, `variable_measured`, `measurement_technique`, `funder`, `license`, `alternate_name`, `editor`, `file_format`, `file_name`, and `file_url` are applied locally after the initial API search using full dataset metadata from `get-dataset`.
 - If you need very precise filtering on those local-only fields, start with a narrower native search first, then apply the local metadata filters.
 - Local metadata filtering only inspects the current API page, so increase `page_size` or adjust `row_start` if you want to scan more native matches.

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -71,6 +71,12 @@ name before using `provider_name`. For example, `Watershed SFA` or
 The shared project reference combines curated portal entries with additional
 projects imported from the ESS-DIVE Mule project registry.
 
+Search results now expose the canonical provider as `dataset.providerName`, which
+`search-datasets` surfaces on a `Provider:` line. Agents can use it to verify which
+provider each result belongs to and to filter out non-matching providers when an
+inexact `provider_name` returns datasets from more than one provider, instead of
+fetching each dataset record individually.
+
 What that enables in practice:
 
 - start with a broad search like `East River`
@@ -158,6 +164,7 @@ To remove them:
 - `Use the essdive-datasets skill to search for East River datasets and then keep only results with Lawrence Berkeley Lab creator affiliations.`
 - `Use the essdive-datasets skill to search for East River datasets and then keep only results where variableMeasured includes streamflow.`
 - `Use the essdive-datasets skill to normalize "Watershed SFA" to the canonical provider name and search for matching datasets.`
+- `Use the essdive-datasets skill to search provider_name="watershed" and keep only results whose providerName is exactly "Watershed Function SFA".`
 
 ### `essdive-identifiers`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "essdive-mcp"
-version = "0.3.4"
+version = "0.3.5"
 description = "MCP Server for ESS-DIVE API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/essdive_mcp/main.py
+++ b/src/essdive_mcp/main.py
@@ -443,6 +443,21 @@ def _organization_search_strings(organization: Dict[str, Any]) -> List[str]:
     return values
 
 
+def _search_result_provider_name(ds_data: Any) -> Optional[str]:
+    """Return the canonical ``providerName`` string from a dataset record.
+
+    ESS-DIVE dataset-search results expose the canonical provider/organization
+    name directly as ``dataset.providerName`` (a plain string). This is the name
+    that matched the ``providerName`` query, so it lets callers verify which
+    provider each result actually belongs to without fetching the full record.
+    """
+    if isinstance(ds_data, dict):
+        name = str(ds_data.get("providerName") or "").strip()
+        if name:
+            return name
+    return None
+
+
 def _summarize_provider(provider: Any) -> List[str]:
     """Return readable provider summaries from dataset metadata."""
     summaries: List[str] = []
@@ -1558,6 +1573,10 @@ def generate_essdive_data_citation(
         provider_name = _citation_provider_name(dataset.get("provider"))
         if not provider_name:
             provider_name = _citation_provider_name(dataset.get("publisher"))
+        if not provider_name:
+            # Dataset-search results expose the canonical provider as a plain
+            # ``providerName`` string instead of a full ``provider`` object.
+            provider_name = sanitize_tsv_field(dataset.get("providerName"))
         repository_clause = "ESS-DIVE repository"
         if provider_name:
             repository_clause = f"{provider_name}, {repository_clause}"
@@ -2466,6 +2485,9 @@ class ESSDiveClient:
                 if _should_show_is_public(dataset.get("isPublic"), results.get("user")):
                     summary += f"   isPublic: {dataset.get('isPublic')}\n"
                 summary += f"   Published: {ds_data.get('datePublished', 'Unknown')}\n"
+                provider_name = _search_result_provider_name(ds_data)
+                if provider_name:
+                    summary += f"   Provider: {provider_name}\n"
                 links = [
                     _markdown_link("View dataset", dataset.get("viewUrl")),
                     _markdown_link("API record", dataset.get("url")),
@@ -2566,9 +2588,13 @@ class ESSDiveClient:
                 if license_value:
                     detailed += f"   License: {license_value}\n"
 
-                providers = _summarize_provider(ds_data.get("provider"))
-                if providers:
-                    detailed += f"   Provider: {'; '.join(providers)}\n"
+                provider_name = _search_result_provider_name(ds_data)
+                if provider_name:
+                    detailed += f"   Provider: {provider_name}\n"
+                else:
+                    providers = _summarize_provider(ds_data.get("provider"))
+                    if providers:
+                        detailed += f"   Provider: {'; '.join(providers)}\n"
 
                 awards = _as_string_list(ds_data.get("award"))
                 if awards:
@@ -2740,6 +2766,10 @@ class ESSDiveClient:
             content += f"{license_value}\n\n"
 
         providers = _summarize_provider(dataset.get("provider"))
+        if not providers:
+            provider_name = _search_result_provider_name(dataset)
+            if provider_name:
+                providers = [provider_name]
         if providers:
             content += "## Provider\n"
             for provider in providers:

--- a/tests/unit/test_api_unit.py
+++ b/tests/unit/test_api_unit.py
@@ -1676,6 +1676,57 @@ class TestFormatResults:
         assert "Award: DOE Award #12345" in formatted
         assert "citation: Example dataset citation" in formatted
 
+    def test_format_results_summary_includes_provider_name(self):
+        """Summary format should surface the canonical providerName from results."""
+        client = ESSDiveClient()
+
+        results = {
+            "result": [
+                {
+                    "id": "ds1",
+                    "dataset": {
+                        "name": "Dataset 1",
+                        "datePublished": "2024-01-01",
+                        "providerName": "Watershed Function SFA",
+                    },
+                }
+            ],
+            "total": 1,
+        }
+
+        formatted = client.format_results(results, "summary")
+
+        assert "Provider: Watershed Function SFA" in formatted
+
+    def test_format_results_detailed_prefers_provider_name(self):
+        """Detailed format should use the canonical providerName when present."""
+        client = ESSDiveClient()
+
+        results = {
+            "result": [
+                {
+                    "id": "ds1",
+                    "dataset": {
+                        "name": "Dataset 1",
+                        "datePublished": "2024-01-01",
+                        "providerName": "River Corridor and Watershed Biogeochemistry SFA",
+                        # A full provider object should be ignored in favor of
+                        # the canonical providerName when both are present.
+                        "provider": {"name": "Some Other Program"},
+                    },
+                }
+            ],
+            "total": 1,
+        }
+
+        formatted = client.format_results(results, "detailed")
+
+        assert (
+            "Provider: River Corridor and Watershed Biogeochemistry SFA"
+            in formatted
+        )
+        assert "Some Other Program" not in formatted
+
     def test_format_results_pagination_note_mentions_previous_page(self):
         """Formatted search results should point agents to previous-page tool."""
         client = ESSDiveClient()
@@ -1912,6 +1963,31 @@ class TestDataCitation:
         assert citation == (
             "Breckheimer I ; Carroll E ; Chadwick K D ; O'Ryan D ; "
             "Worsham H M (2026): CHESS 2025: Field-collected vegetation "
+            "attributes and site photos. Watershed Function SFA, ESS-DIVE "
+            "repository. Dataset. doi:10.15485/3014404 accessed via "
+            "ESS-DIVE API over ESS-DIVE MCP on 2026-05-06"
+        )
+
+    def test_generate_essdive_data_citation_uses_provider_name_string(self):
+        """Search-result datasets expose providerName instead of a provider object."""
+        metadata = {
+            "id": "ess-dive-c867baa5f602eed-20260506T011608834",
+            "dataset": {
+                "@id": "doi:10.15485/3014404",
+                "name": "CHESS 2025: Field-collected vegetation attributes and site photos",
+                "datePublished": "2026-03-10",
+                "creator": [
+                    {"givenName": "Ian", "familyName": "Breckheimer"},
+                ],
+                "providerName": "Watershed Function SFA",
+            },
+        }
+
+        citation = generate_essdive_data_citation(
+            metadata, access_date="2026-05-06")
+
+        assert citation == (
+            "Breckheimer I (2026): CHESS 2025: Field-collected vegetation "
             "attributes and site photos. Watershed Function SFA, ESS-DIVE "
             "repository. Dataset. doi:10.15485/3014404 accessed via "
             "ESS-DIVE API over ESS-DIVE MCP on 2026-05-06"


### PR DESCRIPTION
## Summary

The ESS-DIVE `/packages` search API now returns the canonical provider name as `dataset.providerName` (a plain string) on every result — the name that actually matched the `providerName` query. This PR wires that field through the MCP and updates the agent skills so callers can verify and filter by provider without extra lookups.

This resolves the concerns raised in [ess-dive/essdive-package-service#438](https://github.com/ess-dive/essdive-package-service/issues/438): previously you could not tell which provider a result belonged to without a per-dataset `get-dataset` request or parsing the citation string, and a tokenized `provider_name` (e.g. `watershed`) silently returned datasets from multiple distinct providers.

Verified live against prod:
- `providerName="Watershed Function SFA"` → 149 results, each with `dataset.providerName = "Watershed Function SFA"`.
- `providerName=watershed` → 234 results spanning `Watershed Function SFA`, `River Corridor and Watershed Biogeochemistry SFA`, and others — now distinguishable via `dataset.providerName`.

## Changes

**Code (`src/essdive_mcp/main.py`)**
- Add `_search_result_provider_name()` to read the canonical `dataset.providerName` string.
- Show a `Provider:` line in both `summary` and `detailed` `search-datasets` output, preferring the canonical `providerName` (search results carry the string; the single-dataset endpoint still carries the full `provider` object, which remains the fallback).
- Fall back to `providerName` in the data-citation repository clause and the single-dataset `Provider` section.

**Skills & docs**
- `essdive-datasets` skill: explain that results expose `dataset.providerName`, that tokenized matching can span multiple providers, and to verify/filter by it rather than issuing per-result `get-dataset` calls.
- `essdive-data-citations` skill and `docs/SKILLS.md`: note the new `providerName` field.

**Tests / version**
- New unit tests for summary/detailed provider formatting and the citation fallback.
- Bump version to `0.3.5`.

## Testing

`python -m pytest tests/unit/` → 170 passed.

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)